### PR TITLE
fix: use correct namespace for QueueExtension

### DIFF
--- a/src/Consumption/QueueExtension.php
+++ b/src/Consumption/QueueExtension.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @since         0.1.0
  * @license       https://opensource.org/licenses/MIT MIT License
  */
-namespace Queue\Queue;
+namespace Queue\Consumption;
 
 use Cake\Event\EventDispatcherTrait;
 use Cake\Log\LogTrait;
@@ -32,7 +32,6 @@ use Enqueue\Consumption\ExtensionInterface;
 use Enqueue\Consumption\Result;
 use Psr\Log\LoggerInterface;
 
-// TODO: Figure out how to avoid needing to set a bunch of empty methods
 class QueueExtension implements ExtensionInterface
 {
     use EventDispatcherTrait;

--- a/src/Shell/WorkerShell.php
+++ b/src/Shell/WorkerShell.php
@@ -25,8 +25,8 @@ use Enqueue\SimpleClient\SimpleClient;
 use LogicException;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Queue\Consumption\QueueExtension;
 use Queue\Queue\Processor;
-use Queue\Queue\QueueExtension;
 
 /**
  * Worker shell command.
@@ -75,7 +75,7 @@ class WorkerShell extends Shell
      * Creates and returns a QueueExtension object
      *
      * @param \Psr\Log\LoggerInterface $logger Logger instance.
-     * @return \Queue\Queue\QueueExtension
+     * @return \Queue\Consumption\QueueExtension
      */
     protected function getQueueExtension(LoggerInterface $logger): QueueExtension
     {


### PR DESCRIPTION
The namespace should follow upstream, which uses Consumption.

Also remove the TODO as this is not possible since there can only be a single consumption extension added to the internal queue consumer.