### PR TITLE
Cleanup

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -148,7 +148,7 @@ The following keys are valid for use within the ``options`` array:
   - description: Time - in integer seconds - to delay message, after which it will be processed. Not all message brokers accept this.
   - type: integer
 
-- ``expires_at``:
+- ``expires``:
 
   - default: ``null``
   - description: Time - in integer seconds - after which the message expires.

--- a/src/Job/Message.php
+++ b/src/Job/Message.php
@@ -78,7 +78,7 @@ class Message implements JsonSerializable
      */
     public function getCallable()
     {
-        return Hash::get($this->parsedBody, 'class', null);
+        return $this->parsedBody['class'] ?? null;
     }
 
     /**

--- a/src/Mailer/QueueTrait.php
+++ b/src/Mailer/QueueTrait.php
@@ -46,7 +46,7 @@ trait QueueTrait
         }
 
         QueueManager::push([MailerJob::class, 'execute'], [
-            'mailerConfig' => Hash::get($options, 'mailerConfig', null),
+            'mailerConfig' => $options['mailerConfig'] ?? null,
             'mailerName' => self::class,
             'action' => $action,
             'args' => $args,

--- a/src/Mailer/QueueTrait.php
+++ b/src/Mailer/QueueTrait.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Queue\Mailer;
 
 use Cake\Mailer\Exception\MissingActionException;
-use Cake\Utility\Hash;
 use Queue\Job\MailerJob;
 use Queue\QueueManager;
 

--- a/src/QueueManager.php
+++ b/src/QueueManager.php
@@ -18,7 +18,6 @@ namespace Queue;
 
 use BadMethodCallException;
 use Cake\Log\Log;
-use Cake\Utility\Hash;
 use Enqueue\Client\Message as ClientMessage;
 use Enqueue\SimpleClient\SimpleClient;
 use LogicException;

--- a/src/QueueManager.php
+++ b/src/QueueManager.php
@@ -151,7 +151,7 @@ class QueueManager
             'config' => 'default',
             'queue' => 'default',
             'delay' => null,
-            'expires_at' => null,
+            'expires' => null,
             'priority' => null,
         ];
 
@@ -170,8 +170,8 @@ class QueueManager
             $message->setDelay($options['delay']);
         }
 
-        if ($options['expires_at']) {
-            $message->setExpire($options['expires_at']);
+        if ($options['expires']) {
+            $message->setExpire($options['expires']);
         }
 
         if ($options['priority']) {

--- a/src/Shell/WorkerShell.php
+++ b/src/Shell/WorkerShell.php
@@ -20,7 +20,6 @@ use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
 use Cake\Core\Configure;
 use Cake\Log\Log;
-use Cake\Utility\Hash;
 use Enqueue\SimpleClient\SimpleClient;
 use LogicException;
 use Psr\Log\LoggerInterface;

--- a/src/Shell/WorkerShell.php
+++ b/src/Shell/WorkerShell.php
@@ -118,7 +118,7 @@ class WorkerShell extends Shell
         $processor = new Processor($logger);
         $extension = $this->getQueueExtension($logger);
 
-        $config = Hash::get($this->params, 'config');
+        $config = $this->params['config'];
         if (!empty($config['listener'])) {
             if (!class_exists($config['listener'])) {
                 throw new LogicException(sprintf('Listener class %s not found', $config['listener']));


### PR DESCRIPTION
- Got rid of the numerous unnecessary Hash::get() calls.
- Renamed `expires_at` to `expires` to be same as key name we use for cookies, for consistency.