### PR TITLE
Rename package

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ composer require enqueue/redis predis/predis:^1
 You can load the plugin using the shell command:
 
 ```
-bin/cake plugin load Queue
+bin/cake plugin load Cake/Queue
 ```
 
 Or you can manually add the loading statement in the **src/Application.php** file of your application:
@@ -37,7 +37,7 @@ Or you can manually add the loading statement in the **src/Application.php** fil
 public function bootstrap()
 {
     parent::bootstrap();
-    $this->addPlugin('Queue');
+    $this->addPlugin('Cake/Queue');
 }
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Queue\\": "src/"
+            "Cake\\Queue\\": "src/"
         }
     },
     "autoload-dev": {

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -30,7 +30,7 @@ pure-php redis:
 Ensure that the plugin is loaded in your ``src/Application.php`` file, within
 the ``Application::bootstrap()`` function::
 
-    $this->addPlugin('Queue');
+    $this->addPlugin('Cake/Queue');
 
 Configuration
 =============
@@ -72,8 +72,8 @@ Create a Job class::
     namespace App\Job;
 
     use Cake\Log\LogTrait;
+    use Cake\Queue\Job\Message;
     use Interop\Queue\Processor;
-    use Queue\Job\Message;
 
     class ExampleJob implements JobInterface
     {
@@ -118,7 +118,7 @@ Queueing
 Queue the messages using the included `Queue\QueueManager` class::
 
     use App\Job\ExampleJob;
-    use Queue\QueueManager;
+    use Cake\Queue\QueueManager;
 
     $callable = [ExampleJob::class, 'execute'];
     $arguments = ['id' => 7, 'data' => 'hi2u'];
@@ -185,7 +185,7 @@ class::
     namespace App\Mailer;
 
     use Cake\Mailer\Mailer;
-    use Queue\Queue\QueueTrait;
+    use Cake\Queue\Queue\QueueTrait;
 
     class UserMailer extends Mailer
     {
@@ -207,7 +207,7 @@ use the ``push()`` method on a mailer instance::
 
     $this->getMailer('User')->push('welcome', ['example@example.com', 'josegonzalez']);
 
-This ``QueueuTrait::push()`` call will generate an intermediate ``MailerJob``
+This ``QueueTrait::push()`` call will generate an intermediate ``MailerJob``
 that handles processing of the email message. If the MailerJob is unable to
 instantiate the Email or Mailer instances, it is interpreted as
 a ``Processor::REJECT``. An invalid ``action`` is also interpreted as
@@ -215,7 +215,7 @@ a ``Processor::REJECT``, as will the action throwing
 a ``BadMethodCallException``. Any non-exception result will be seen as
 a ``Processor:ACK``.
 
-The exposed ``QueueuTrait::push()`` method has a similar signature to
+The exposed ``QueueTrait::push()`` method has a similar signature to
 ``Mailer::send()``, and also supports an ``$options`` array argument. The
 options this array holds are the same options as those available for
 ``QueueManager::push()``, and additionally supports the following:

--- a/src/Consumption/QueueExtension.php
+++ b/src/Consumption/QueueExtension.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @since         0.1.0
  * @license       https://opensource.org/licenses/MIT MIT License
  */
-namespace Queue\Consumption;
+namespace Cake\Queue\Consumption;
 
 use Cake\Event\EventDispatcherTrait;
 use Cake\Log\LogTrait;

--- a/src/Job/JobInterface.php
+++ b/src/Job/JobInterface.php
@@ -14,14 +14,14 @@ declare(strict_types=1);
  * @since         0.1.0
  * @license       https://opensource.org/licenses/MIT MIT License
  */
-namespace Queue\Job;
+namespace Cake\Queue\Job;
 
 interface JobInterface
 {
     /**
      * Executes logic for {{ name }}Job
      *
-     * @param \Queue\Job\Message $message job message
+     * @param \Cake\Queue\Job\Message $message job message
      * @return string
      */
     public function execute(Message $message): ?string;

--- a/src/Job/MailerJob.php
+++ b/src/Job/MailerJob.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @since         0.1.0
  * @license       https://opensource.org/licenses/MIT MIT License
  */
-namespace Queue\Job;
+namespace Cake\Queue\Job;
 
 use BadMethodCallException;
 use Cake\Mailer\Exception\MissingMailerException;
@@ -28,7 +28,7 @@ class MailerJob implements JobInterface
     /**
      * Constructs and dispatches the event from a job message
      *
-     * @param \Queue\Job\Message $message job message
+     * @param Cake\Queue\Job\Message $message job message
      * @return string
      */
     public function execute(Message $message): ?string

--- a/src/Job/MailerJob.php
+++ b/src/Job/MailerJob.php
@@ -28,7 +28,7 @@ class MailerJob implements JobInterface
     /**
      * Constructs and dispatches the event from a job message
      *
-     * @param Cake\Queue\Job\Message $message job message
+     * @param \Cake\Queue\Job\Message $message job message
      * @return string
      */
     public function execute(Message $message): ?string

--- a/src/Job/Message.php
+++ b/src/Job/Message.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @since         0.1.0
  * @license       https://opensource.org/licenses/MIT MIT License
  */
-namespace Queue\Job;
+namespace Cake\Queue\Job;
 
 use Cake\Utility\Hash;
 use Interop\Queue\Context;

--- a/src/Mailer/QueueTrait.php
+++ b/src/Mailer/QueueTrait.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @since         0.1.0
  * @license       https://opensource.org/licenses/MIT MIT License
  */
-namespace Queue\Mailer;
+namespace Cake\Queue\Mailer;
 
 use Cake\Mailer\Exception\MissingActionException;
 use Queue\Job\MailerJob;

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @since         0.1.0
  * @license       https://opensource.org/licenses/MIT MIT License
  */
-namespace Queue;
+namespace Cake\Queue;
 
 use Cake\Core\BasePlugin;
 use Cake\Core\Configure;
@@ -30,7 +30,7 @@ class Plugin extends BasePlugin
      *
      * @var string
      */
-    protected $name = 'Queue';
+    protected $name = 'Cake/Queue';
 
     /**
      * Load the Queue configuration

--- a/src/Queue/Processor.php
+++ b/src/Queue/Processor.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @since         0.1.0
  * @license       https://opensource.org/licenses/MIT MIT License
  */
-namespace Queue\Queue;
+namespace Cake\Queue\Queue;
 
 use Cake\Event\EventDispatcherTrait;
 use Cake\Log\LogTrait;
@@ -24,7 +24,7 @@ use Interop\Queue\Message as QueueMessage;
 use Interop\Queue\Processor as InteropProcessor;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Queue\Job\Message;
+use Cake\Queue\Job\Message;
 
 class Processor implements InteropProcessor
 {
@@ -100,7 +100,7 @@ class Processor implements InteropProcessor
     }
 
     /**
-     * @param \Queue\Job\Message $message Message.
+     * @param Cake\Queue\Job\Message $message Message.
      * @return string|object with __toString method implemented
      */
     public function processMessage(Message $message)

--- a/src/Queue/Processor.php
+++ b/src/Queue/Processor.php
@@ -18,13 +18,13 @@ namespace Cake\Queue\Queue;
 
 use Cake\Event\EventDispatcherTrait;
 use Cake\Log\LogTrait;
+use Cake\Queue\Job\Message;
 use Exception;
 use Interop\Queue\Context;
 use Interop\Queue\Message as QueueMessage;
 use Interop\Queue\Processor as InteropProcessor;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Cake\Queue\Job\Message;
 
 class Processor implements InteropProcessor
 {
@@ -100,7 +100,7 @@ class Processor implements InteropProcessor
     }
 
     /**
-     * @param Cake\Queue\Job\Message $message Message.
+     * @param \Cake\Queue\Job\Message $message Message.
      * @return string|object with __toString method implemented
      */
     public function processMessage(Message $message)

--- a/src/QueueManager.php
+++ b/src/QueueManager.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @since         0.1.0
  * @license       https://opensource.org/licenses/MIT MIT License
  */
-namespace Queue;
+namespace Cake\Queue;
 
 use BadMethodCallException;
 use Cake\Log\Log;

--- a/src/Shell/Task/JobTask.php
+++ b/src/Shell/Task/JobTask.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
  * @since         0.1.0
  * @license       https://opensource.org/licenses/MIT MIT License
  */
-namespace Queue\Shell\Task;
+namespace Cake\Queue\Shell\Task;
 
 use Bake\Shell\Task\SimpleBakeTask;
 
@@ -44,6 +44,6 @@ class JobTask extends SimpleBakeTask
      */
     public function template(): string
     {
-        return 'Queue.job';
+        return 'Cake/Queue.job';
     }
 }

--- a/src/Shell/WorkerShell.php
+++ b/src/Shell/WorkerShell.php
@@ -14,18 +14,18 @@ declare(strict_types=1);
  * @since         0.1.0
  * @license       https://opensource.org/licenses/MIT MIT License
  */
-namespace Queue\Shell;
+namespace Cake\Queue\Shell;
 
 use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
 use Cake\Core\Configure;
 use Cake\Log\Log;
+use Cake\Queue\Consumption\QueueExtension;
+use Cake\Queue\Queue\Processor;
 use Enqueue\SimpleClient\SimpleClient;
 use LogicException;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Queue\Consumption\QueueExtension;
-use Queue\Queue\Processor;
 
 /**
  * Worker shell command.
@@ -76,7 +76,7 @@ class WorkerShell extends Shell
      * Creates and returns a QueueExtension object
      *
      * @param \Psr\Log\LoggerInterface $logger Logger instance.
-     * @return \Queue\Consumption\QueueExtension
+     * @return \Cake\Queue\Consumption\QueueExtension
      */
     protected function getQueueExtension(LoggerInterface $logger): QueueExtension
     {

--- a/templates/bake/job.twig
+++ b/templates/bake/job.twig
@@ -18,8 +18,8 @@ declare(strict_types=1);
 
 namespace {{ namespace }}\Job;
 
+use Cake\Queue\Job\Message;
 use Interop\Queue\Processor;
-use Queue\Job\Message;
 
 /**
  * {{ name }} job
@@ -29,7 +29,7 @@ class {{ name }}Job
     /**
      * Executes logic for {{ name }}Job
      *
-     * @param \Queue\Job\Message $message job message
+     * @param \Cake\Queue\Job\Message $message job message
      * @return string
      */
     public function execute(Message $message): string

--- a/tests/TestCase/Job/MailerJobTest.php
+++ b/tests/TestCase/Job/MailerJobTest.php
@@ -18,12 +18,12 @@ namespace Queue\Test\TestCase\Job;
 
 use Cake\Mailer\Exception\MissingMailerException;
 use Cake\Mailer\Mailer;
+use Cake\Queue\Job\MailerJob;
+use Cake\Queue\Job\Message;
+use Cake\Queue\Queue\Processor;
 use Cake\TestSuite\TestCase;
 use Enqueue\Null\NullConnectionFactory;
 use Enqueue\Null\NullMessage;
-use Queue\Job\MailerJob;
-use Queue\Job\Message;
-use Queue\Queue\Processor;
 
 class MailerJobTest extends TestCase
 {
@@ -32,7 +32,7 @@ class MailerJobTest extends TestCase
      */
     protected $mailer;
     /**
-     * @var \Queue\Job\MailerJob|\PHPUnit\Framework\MockObject\MockObject
+     * @var Cake\Queue\Job\MailerJob|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $job;
     protected $mailerConfig;

--- a/tests/TestCase/Job/MailerJobTest.php
+++ b/tests/TestCase/Job/MailerJobTest.php
@@ -144,14 +144,14 @@ class MailerJobTest extends TestCase
     protected function createMessage(): Message
     {
         $messageBody = [
-            "queue" => "default",
-            "class" => ["Queue\\Job\\EventJob", "execute"],
-            "args" => [
+            'queue' => 'default',
+            'class' => ['Queue\\Job\\EventJob', 'execute'],
+            'args' => [
                 [
-                    "mailerName" => "SampleTest",
-                    "mailerConfig" => $this->mailerConfig,
-                    "action" => 'welcome',
-                    "args" => $this->args,
+                    'mailerName' => 'SampleTest',
+                    'mailerConfig' => $this->mailerConfig,
+                    'action' => 'welcome',
+                    'args' => $this->args,
                     'headers' => $this->headers,
                 ],
             ],

--- a/tests/TestCase/Job/MessageTest.php
+++ b/tests/TestCase/Job/MessageTest.php
@@ -30,14 +30,14 @@ class MessageTest extends TestCase
      */
     public function testConstructorAndGetters()
     {
-        $callable = ["App\\Job\\ExampleJob","execute"];
-        $data = "sample data " . time();
+        $callable = ['App\\Job\\ExampleJob','execute'];
+        $data = 'sample data ' . time();
         $id = 7;
         $args = compact('id', 'data');
         $parsedBody = [
-            "queue" => "default",
-            "class" => $callable,
-            "args" => [$args],
+            'queue' => 'default',
+            'class' => $callable,
+            'args' => [$args],
         ];
         $messageBody = json_encode($parsedBody);
         $connectionFactory = new NullConnectionFactory();

--- a/tests/TestCase/Job/MessageTest.php
+++ b/tests/TestCase/Job/MessageTest.php
@@ -16,10 +16,10 @@ declare(strict_types=1);
  */
 namespace Queue\Test\TestCase\Job;
 
+use Cake\Queue\Job\Message;
 use Cake\TestSuite\TestCase;
 use Enqueue\Null\NullConnectionFactory;
 use Enqueue\Null\NullMessage;
-use Queue\Job\Message;
 
 class MessageTest extends TestCase
 {

--- a/tests/TestCase/Queue/ProcessorTest.php
+++ b/tests/TestCase/Queue/ProcessorTest.php
@@ -18,12 +18,12 @@ namespace Queue\Test\TestCase\Queue;
 
 use Cake\Event\EventList;
 use Cake\Log\Engine\ArrayLog;
+use Cake\Queue\Job\Message;
+use Cake\Queue\Queue\Processor;
 use Cake\TestSuite\TestCase;
 use Enqueue\Null\NullConnectionFactory;
 use Enqueue\Null\NullMessage;
 use Interop\Queue\Processor as InteropProcessor;
-use Cake\Queue\Job\Message;
-use Cake\Queue\Queue\Processor;
 
 class ProcessorTest extends TestCase
 {
@@ -57,9 +57,9 @@ class ProcessorTest extends TestCase
     public function testProcess($jobMethod, $expected, $logMessage, $dispatchedEvent)
     {
         $messageBody = [
-            "queue" => "default",
-            "class" => [static::class, $jobMethod],
-            "args" => [],
+            'queue' => 'default',
+            'class' => [static::class, $jobMethod],
+            'args' => [],
         ];
         $connectionFactory = new NullConnectionFactory();
         $context = $connectionFactory->createContext();
@@ -98,11 +98,11 @@ class ProcessorTest extends TestCase
     public function testProcessNotValidCallable()
     {
         $messageBody = [
-            "queue" => "default",
-            "class" => ["NotValid\\ClassName\\FakeJob", "execute"],
-            "args" => [
+            'queue' => 'default',
+            'class' => ['NotValid\\ClassName\\FakeJob', 'execute'],
+            'args' => [
                 [
-                    "data" => ['sample_data' => 'a value'],
+                    'data' => ['sample_data' => 'a value'],
                 ],
             ],
         ];
@@ -137,9 +137,9 @@ class ProcessorTest extends TestCase
     public function testProcessMessage()
     {
         $messageBody = [
-            "queue" => "default",
-            "class" => [static::class, "processReturnAck"],
-            "args" => [],
+            'queue' => 'default',
+            'class' => [static::class, 'processReturnAck'],
+            'args' => [],
         ];
         $connectionFactory = new NullConnectionFactory();
         $context = $connectionFactory->createContext();
@@ -243,11 +243,11 @@ class ProcessorTest extends TestCase
     public function testProcessMessageCallableIsString($method, $expected)
     {
         $messageBody = [
-            "queue" => "default",
-            "class" => static::class . '::' . $method,
-            "args" => [
+            'queue' => 'default',
+            'class' => static::class . '::' . $method,
+            'args' => [
                 [
-                    "data" => ['sample_data' => 'a value', 'key' => md5($method)],
+                    'data' => ['sample_data' => 'a value', 'key' => md5($method)],
                 ],
             ],
         ];

--- a/tests/TestCase/Queue/ProcessorTest.php
+++ b/tests/TestCase/Queue/ProcessorTest.php
@@ -22,8 +22,8 @@ use Cake\TestSuite\TestCase;
 use Enqueue\Null\NullConnectionFactory;
 use Enqueue\Null\NullMessage;
 use Interop\Queue\Processor as InteropProcessor;
-use Queue\Job\Message;
-use Queue\Queue\Processor;
+use Cake\Queue\Job\Message;
+use Cake\Queue\Queue\Processor;
 
 class ProcessorTest extends TestCase
 {

--- a/tests/TestCase/QueueManagerTest.php
+++ b/tests/TestCase/QueueManagerTest.php
@@ -18,8 +18,8 @@ namespace Queue\Test\TestCase;
 
 use BadMethodCallException;
 use Cake\Log\Log;
-use Cake\TestSuite\TestCase;
 use Cake\Queue\QueueManager;
+use Cake\TestSuite\TestCase;
 use Enqueue\SimpleClient\SimpleClient;
 use LogicException;
 

--- a/tests/TestCase/QueueManagerTest.php
+++ b/tests/TestCase/QueueManagerTest.php
@@ -19,9 +19,9 @@ namespace Queue\Test\TestCase;
 use BadMethodCallException;
 use Cake\Log\Log;
 use Cake\TestSuite\TestCase;
+use Cake\Queue\QueueManager;
 use Enqueue\SimpleClient\SimpleClient;
 use LogicException;
-use Queue\QueueManager;
 
 /**
  * QueueManager test

--- a/tests/TestCase/Task/JobTaskTest.php
+++ b/tests/TestCase/Task/JobTaskTest.php
@@ -19,8 +19,8 @@ namespace Queue\Test\TestCase\Task;
 use Cake\Command\Command;
 use Cake\Queue\QueueManager;
 use Cake\TestSuite\ConsoleIntegrationTestTrait;
-use Cake\TestSuite\TestCase;
 use Cake\TestSuite\StringCompareTrait;
+use Cake\TestSuite\TestCase;
 
 /**
  * JobTask test class

--- a/tests/TestCase/Task/JobTaskTest.php
+++ b/tests/TestCase/Task/JobTaskTest.php
@@ -16,15 +16,18 @@ declare(strict_types=1);
  */
 namespace Queue\Test\TestCase\Task;
 
-use Cake\Console\Command;
-use Cake\TestSuite\ConsoleIntegrationTestCase;
+use Cake\Command\Command;
+use Cake\Queue\QueueManager;
+use Cake\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\TestCase;
 use Cake\TestSuite\StringCompareTrait;
 
 /**
  * JobTask test class
  */
-class JobTaskTest extends ConsoleIntegrationTestCase
+class JobTaskTest extends TestCase
 {
+    use ConsoleIntegrationTestTrait;
     use StringCompareTrait;
 
     /**
@@ -43,6 +46,7 @@ class JobTaskTest extends ConsoleIntegrationTestCase
 
         $this->comparisonDir = dirname(dirname(__DIR__)) . DS . 'comparisons' . DS;
         $this->useCommandRunner();
+        QueueManager::drop('default');
     }
 
     public function tearDown(): void

--- a/tests/app/TestApp/Application.php
+++ b/tests/app/TestApp/Application.php
@@ -20,7 +20,7 @@ class Application extends BaseApplication
 
     public function bootstrap(): void
     {
-        $this->addPlugin('Queue');
+        $this->addPlugin('Cake/Queue');
         $this->addPlugin('Bake');
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 
 use Cake\Core\Configure;
-use Cake\Core\Plugin;
 use Cake\Routing\Router;
 
 $findRoot = function ($root) {
@@ -46,6 +45,7 @@ if (!defined('CONFIG')) {
     define('CONFIG', ROOT . DS . 'config' . DS);
 }
 
+Configure::write('debug', true);
 Configure::write('App', [
     'namespace' => 'TestApp',
     'encoding' => 'UTF-8',
@@ -77,6 +77,5 @@ Cake\Datasource\ConnectionManager::setConfig('test', [
     'url' => getenv('db_dsn'),
     'timezone' => 'UTC',
 ]);
-Plugin::getCollection()->add(new \Queue\Plugin());
 
 Router::reload();

--- a/tests/comparisons/JobTask.php
+++ b/tests/comparisons/JobTask.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace TestApp\Job;
 
+use Cake\Queue\Job\Message;
 use Interop\Queue\Processor;
-use Queue\Job\Message;
 
 /**
  * Upload job
@@ -14,7 +14,7 @@ class UploadJob
     /**
      * Executes logic for UploadJob
      *
-     * @param \Queue\Job\Message $message job message
+     * @param \Cake\Queue\Job\Message $message job message
      * @return string
      */
     public function execute(Message $message): string


### PR DESCRIPTION
After going through the RFC the bulk of the support for the rename was to keep something simple and not cute. Furthermore a few folks requested that we didn't use the top level `Queue` namespace. Our historical   convention on this has been mixed.

Most of our plugins do not have the Cake prefix (Authorization, Authentication, Bake, DebugKit, Migrations), however ElasticSearch does as it overlaps another library that has a similar name. I think this library is in a similar position with Enqueue.

Closes #9

