### PR TITLE
Test improvements about assertions

### DIFF
--- a/tests/TestCase/Job/MessageTest.php
+++ b/tests/TestCase/Job/MessageTest.php
@@ -54,7 +54,7 @@ class MessageTest extends TestCase
         $this->assertSame($id, $message->getArgument('id'));
         $this->assertSame($data, $message->getArgument('data', 'ignore_this'));
         $this->assertSame('should_use_this', $message->getArgument('unknown', 'should_use_this'));
-        $this->assertSame(null, $message->getArgument('unknown'));
+        $this->assertNull($message->getArgument('unknown'));
         $actualJson = json_encode($message);
         $this->assertSame($messageBody, $actualJson);
         $actualToStringValue = (string)$message;

--- a/tests/TestCase/Queue/ProcessorTest.php
+++ b/tests/TestCase/Queue/ProcessorTest.php
@@ -72,7 +72,7 @@ class ProcessorTest extends TestCase
         $processor->getEventManager()->setEventList($events);
 
         $actual = $processor->process($queueMessage, $context);
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
 
         $logs = $logger->read();
         $this->assertCount(1, $logs);
@@ -117,7 +117,7 @@ class ProcessorTest extends TestCase
 
         $actual = $processor->process($queueMessage, $context);
         $expected = InteropProcessor::REJECT;
-        $this->assertEquals($expected, $actual);
+        $this->assertSame($expected, $actual);
 
         $logs = $logger->read();
         $this->assertCount(1, $logs);


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to replace `assertEquals` and it can make assertion equal strict.
- Using the `assertNull` to assert expected is `null`.