### PR TITLE
Queue trait tests

### DIFF
--- a/src/Mailer/QueueTrait.php
+++ b/src/Mailer/QueueTrait.php
@@ -17,8 +17,8 @@ declare(strict_types=1);
 namespace Cake\Queue\Mailer;
 
 use Cake\Mailer\Exception\MissingActionException;
-use Queue\Job\MailerJob;
-use Queue\QueueManager;
+use Cake\Queue\Job\MailerJob;
+use Cake\Queue\QueueManager;
 
 /**
  * Provides functionality for queuing actions from mailer classes.

--- a/tests/TestCase/Mailer/QueueTraitTest.php
+++ b/tests/TestCase/Mailer/QueueTraitTest.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         0.1.0
+ * @license       https://opensource.org/licenses/MIT MIT License
+ */
+namespace Queue\Test\TestCase\Mailer;
+
+use Cake\Mailer\Exception\MissingActionException;
+use Cake\Queue\Mailer\QueueTrait;
+use Cake\Queue\QueueManager;
+use Cake\TestSuite\TestCase;
+
+class QueueTraitTest extends TestCase
+{
+    /**
+     * Test that a MissingActionException is being thrown when
+     * the push action is not found on the object with the QueueTrait
+     *
+     * @return @void
+     */
+    public function testQueueTraitTestThrowsMissingActionException()
+    {
+        $queue = $this->getMockForTrait(
+            QueueTrait::class,
+            [],
+            'GenericMailer',
+            true,
+            true,
+            true,
+            ['getName']
+        );
+
+        try {
+            $queue->push('nonExistentFunction');
+        } catch (MissingActionException $e) {
+            $this->assertInstanceOf(MissingActionException::class, $e);
+        }
+    }
+
+    /**
+     * Test that a MissingActionException is being thrown when
+     * the push action is not found on the object with the QueueTrait
+     *
+     * @return @void
+     */
+    public function testQueueTraitCallsPush()
+    {
+        $queue = $this->getMockForTrait(
+            QueueTrait::class,
+            [],
+            'GenericMailer',
+            true,
+            true,
+            true,
+            ['getName']
+        );
+
+        QueueManager::setConfig('default', [
+            'queue' => 'default',
+            'url' => 'null:',
+        ]);
+
+        $this->assertEmpty($queue->push('push'));
+    }
+}

--- a/tests/TestCase/Mailer/QueueTraitTest.php
+++ b/tests/TestCase/Mailer/QueueTraitTest.php
@@ -49,8 +49,7 @@ class QueueTraitTest extends TestCase
     }
 
     /**
-     * Test that a MissingActionException is being thrown when
-     * the push action is not found on the object with the QueueTrait
+     * Test that QueueTrait calls push
      *
      * @return @void
      */


### PR DESCRIPTION
The QueueTrait referenced 2 classes:

```php
use Queue\Job\MailerJob;
use Queue\QueueManager;
```
I think it's meant to be:

```php
use Cake\Queue\Job\MailerJob;
use Cake\Queue\QueueManager;
```
I updated the import statements. Also I provided a unit test of the QueueTrait.



