### PR TITLE
Fix failing QueueTrait tests.

### DIFF
--- a/src/Job/JobInterface.php
+++ b/src/Job/JobInterface.php
@@ -19,7 +19,7 @@ namespace Cake\Queue\Job;
 interface JobInterface
 {
     /**
-     * Executes logic for {{ name }}Job
+     * Executes logic for Job
      *
      * @param \Cake\Queue\Job\Message $message job message
      * @return string

--- a/src/Mailer/QueueTrait.php
+++ b/src/Mailer/QueueTrait.php
@@ -39,14 +39,14 @@ trait QueueTrait
     {
         if (!method_exists($this, $action)) {
             throw new MissingActionException([
-                'mailer' => $this->getName() . 'Mailer',
+                'mailer' => static::class,
                 'action' => $action,
             ]);
         }
 
         QueueManager::push([MailerJob::class, 'execute'], [
             'mailerConfig' => $options['mailerConfig'] ?? null,
-            'mailerName' => self::class,
+            'mailerName' => static::class,
             'action' => $action,
             'args' => $args,
             'headers' => $headers,

--- a/src/QueueManager.php
+++ b/src/QueueManager.php
@@ -168,7 +168,9 @@ class QueueManager
             !is_array($callable) ||
             (is_array($callable) && !class_exists($callable[0]))
         ) {
-            throw new InvalidArgumentException('Invalid callable provided. Please use either an array of `[classname, method]` or a string.');
+            throw new InvalidArgumentException(
+                'Invalid callable provided. Please use either an array of `[classname, method]` or a string.'
+            );
         }
         $options += [
             'config' => 'default',

--- a/src/QueueManager.php
+++ b/src/QueueManager.php
@@ -151,10 +151,10 @@ class QueueManager
     /**
      * Push a single job onto the queue.
      *
-     * @param string|array $callable Either an array of [classname, method].
-     *   The class will be constructed by Queue\Processor and have the
-     *   named method invoked. Or a string to a statically callable
-     *   function.
+     * @param string|array $callable Either an array of [classname, method], or a string
+     *   to a statically callable function. When an array is used, the
+     *   class will be constructed by Queue\Processor and have the
+     *   named method invoked.
      * @param array $args An array of data to set for the job
      * @param array $options An array of options for publishing the job
      * @return void

--- a/src/QueueManager.php
+++ b/src/QueueManager.php
@@ -151,7 +151,7 @@ class QueueManager
     /**
      * Push a single job onto the queue.
      *
-     * @param string|array $callable Either an array of [classname, method], or a string
+     * @param string|string[] $callable Either an array of [classname, method], or a string
      *   to a statically callable function. When an array is used, the
      *   class will be constructed by Queue\Processor and have the
      *   named method invoked.
@@ -163,11 +163,7 @@ class QueueManager
     {
         // We can't use the callable type as it checks that the
         // [class, method] is statically callable which won't be true.
-        if (
-            !is_string($callable) &&
-            !is_array($callable) ||
-            (is_array($callable) && !class_exists($callable[0]))
-        ) {
+        if (is_array($callable) && !class_exists($callable[0])) {
             throw new InvalidArgumentException(
                 'Invalid callable provided. Please use either an array of `[classname, method]` or a string.'
             );

--- a/src/QueueManager.php
+++ b/src/QueueManager.php
@@ -20,6 +20,7 @@ use BadMethodCallException;
 use Cake\Log\Log;
 use Enqueue\Client\Message as ClientMessage;
 use Enqueue\SimpleClient\SimpleClient;
+use InvalidArgumentException;
 use LogicException;
 
 class QueueManager
@@ -150,13 +151,25 @@ class QueueManager
     /**
      * Push a single job onto the queue.
      *
-     * @param callable $callable  a job callable
-     * @param array $args         an array of data to set for the job
-     * @param array $options      an array of options for publishing the job
+     * @param string|array $callable Either an array of [classname, method].
+     *   The class will be constructed by Queue\Processor and have the
+     *   named method invoked. Or a string to a statically callable
+     *   function.
+     * @param array $args An array of data to set for the job
+     * @param array $options An array of options for publishing the job
      * @return void
      */
-    public static function push(callable $callable, array $args = [], array $options = []): void
+    public static function push($callable, array $args = [], array $options = []): void
     {
+        // We can't use the callable type as it checks that the
+        // [class, method] is statically callable which won't be true.
+        if (
+            !is_string($callable) &&
+            !is_array($callable) ||
+            (is_array($callable) && !class_exists($callable[0]))
+        ) {
+            throw new InvalidArgumentException('Invalid callable provided. Please use either an array of `[classname, method]` or a string.');
+        }
         $options += [
             'config' => 'default',
             'queue' => 'default',

--- a/tests/TestCase/Mailer/QueueTraitTest.php
+++ b/tests/TestCase/Mailer/QueueTraitTest.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Queue\Test\TestCase\Mailer;
 
 use Cake\Mailer\Exception\MissingActionException;
-use Cake\Queue\Mailer\QueueTrait;
 use Cake\Queue\QueueManager;
 use Cake\TestSuite\TestCase;
 use TestApp\WelcomeMailer;

--- a/tests/TestCase/Mailer/QueueTraitTest.php
+++ b/tests/TestCase/Mailer/QueueTraitTest.php
@@ -20,6 +20,7 @@ use Cake\Mailer\Exception\MissingActionException;
 use Cake\Queue\Mailer\QueueTrait;
 use Cake\Queue\QueueManager;
 use Cake\TestSuite\TestCase;
+use TestApp\WelcomeMailer;
 
 class QueueTraitTest extends TestCase
 {
@@ -31,21 +32,9 @@ class QueueTraitTest extends TestCase
      */
     public function testQueueTraitTestThrowsMissingActionException()
     {
-        $queue = $this->getMockForTrait(
-            QueueTrait::class,
-            [],
-            'GenericMailer',
-            true,
-            true,
-            true,
-            ['getName']
-        );
-
-        try {
-            $queue->push('nonExistentFunction');
-        } catch (MissingActionException $e) {
-            $this->assertInstanceOf(MissingActionException::class, $e);
-        }
+        $queue = new WelcomeMailer();
+        $this->expectException(MissingActionException::class);
+        $queue->push('nonExistentFunction');
     }
 
     /**
@@ -55,21 +44,12 @@ class QueueTraitTest extends TestCase
      */
     public function testQueueTraitCallsPush()
     {
-        $queue = $this->getMockForTrait(
-            QueueTrait::class,
-            [],
-            'GenericMailer',
-            true,
-            true,
-            true,
-            ['getName']
-        );
-
+        $queue = new WelcomeMailer();
         QueueManager::setConfig('default', [
             'queue' => 'default',
             'url' => 'null:',
         ]);
 
-        $this->assertEmpty($queue->push('push'));
+        $this->assertEmpty($queue->push('welcome'));
     }
 }

--- a/tests/TestCase/QueueManagerTest.php
+++ b/tests/TestCase/QueueManagerTest.php
@@ -82,4 +82,11 @@ class QueueManagerTest extends TestCase
 
         $this->assertSame($engine, QueueManager::engine('test'));
     }
+
+    public function testPushInvalidClass()
+    {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('Invalid callable provided.');
+        QueueManager::push(['Nope', 'lol']);
+    }
 }

--- a/tests/app/TestApp/WelcomeMailer.php
+++ b/tests/app/TestApp/WelcomeMailer.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp;
+
+use Cake\Mailer\Mailer;
+use Cake\Queue\Mailer\QueueTrait;
+
+class WelcomeMailer extends Mailer
+{
+    use QueueTrait;
+
+    public function getName()
+    {
+    }
+
+    public function welcome()
+    {
+        // Do nothing.
+    }
+}


### PR DESCRIPTION
The tests provided in #30 exposed a few more problems that needed to be
fixed.

* The getName() method doesn't exist on Mailer.
* The `callable` type requires the value to be statically callable,
  which MailerJob::execute() is not.
* I'm not a fan of mocks and would rather test with an implementation.