### PR TITLE
WorkerShell to WorkerCommand

### DIFF
--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -124,9 +124,14 @@ class WorkerCommand extends Command
         $extension = $this->getQueueExtension($args, $logger);
 
         $config = $args->getOption('config');
-        $listenerClassName = Configure::read(sprintf('Queue.%s.listener', $config));
+        if (!Configure::check(sprintf('Queue.%s', $config))) {
+            $io->error(sprintf('Configuration key "%s" was not found', $config));
+            $this->abort();
+        }
 
-        if (!empty($listenerClassName)) {
+        $hasListener = Configure::check(sprintf('Queue.%s.listener', $config));
+        if ($hasListener) {
+            $listenerClassName = Configure::read(sprintf('Queue.%s.listener', $config));
             if (!class_exists($listenerClassName)) {
                 $io->error(sprintf('Listener class %s not found', $listenerClassName));
                 $this->abort();

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -14,10 +14,12 @@ declare(strict_types=1);
  * @since         0.1.0
  * @license       https://opensource.org/licenses/MIT MIT License
  */
-namespace Cake\Queue\Shell;
+namespace Cake\Queue\Command;
 
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
-use Cake\Console\Shell;
 use Cake\Core\Configure;
 use Cake\Log\Log;
 use Cake\Queue\Consumption\QueueExtension;
@@ -28,9 +30,9 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 /**
- * Worker shell command.
+ * Worker command.
  */
-class WorkerShell extends Shell
+class WorkerCommand extends Command
 {
     /**
      * Gets the option parser instance and configures it.
@@ -40,6 +42,7 @@ class WorkerShell extends Shell
     public function getOptionParser(): ConsoleOptionParser
     {
         $parser = parent::getOptionParser();
+
         $parser->addOption('config', [
             'default' => 'default',
             'help' => 'Name of a queue config to use',
@@ -78,10 +81,10 @@ class WorkerShell extends Shell
      * @param \Psr\Log\LoggerInterface $logger Logger instance.
      * @return \Cake\Queue\Consumption\QueueExtension
      */
-    protected function getQueueExtension(LoggerInterface $logger): QueueExtension
+    protected function getQueueExtension(Arguments $args, LoggerInterface $logger): QueueExtension
     {
-        $maxIterations = $this->param('max-iterations');
-        $maxRuntime = $this->param('max-runtime');
+        $maxIterations = (int)$args->getOption('max-iterations');
+        $maxRuntime = (int)$args->getOption('max-runtime');
         if ($maxIterations === null) {
             $maxIterations = 0;
         }
@@ -96,30 +99,31 @@ class WorkerShell extends Shell
     /**
      * Creates and returns a LoggerInterface object
      *
+     * @param Arguments $args
      * @return \Psr\Log\LoggerInterface
      */
-    protected function getLogger(): LoggerInterface
+    protected function getLogger(Arguments $args): LoggerInterface
     {
         $logger = new NullLogger();
-        if (!empty($this->params['verbose'])) {
-            $logger = Log::engine($this->params['logger']);
+        if (!empty($args->getOption('verbose'))) {
+            $logger = Log::engine($args->getOption('logger'));
         }
 
         return $logger;
     }
 
     /**
-     * main() method.
-     *
-     * @return null
+     * @param  Arguments  $args
+     * @param  ConsoleIo  $io
+     * @return int|void|null
      */
-    public function main()
+    public function execute(Arguments $args, ConsoleIo $io)
     {
-        $logger = $this->getLogger();
+        $logger = $this->getLogger($args);
         $processor = new Processor($logger);
-        $extension = $this->getQueueExtension($logger);
+        $extension = $this->getQueueExtension($args, $logger);
 
-        $config = $this->params['config'];
+        $config = $args->getOption('config');
         if (!empty($config['listener'])) {
             if (!class_exists($config['listener'])) {
                 throw new LogicException(sprintf('Listener class %s not found', $config['listener']));
@@ -129,12 +133,9 @@ class WorkerShell extends Shell
             $processor->getEventManager()->on($listener);
             $extension->getEventManager()->on($listener);
         }
-
         $url = Configure::read(sprintf('Queue.%s.url', $config));
         $client = new SimpleClient($url, $logger);
-        $client->bindTopic($this->params['queue'], $processor);
+        $client->bindTopic($args->getOption('queue'), $processor);
         $client->consume($extension);
-
-        return null;
     }
 }

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -25,7 +25,6 @@ use Cake\Log\Log;
 use Cake\Queue\Consumption\QueueExtension;
 use Cake\Queue\Queue\Processor;
 use Enqueue\SimpleClient\SimpleClient;
-use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 

--- a/tests/TestCase/Command/WorkerCommandTest.php
+++ b/tests/TestCase/Command/WorkerCommandTest.php
@@ -19,6 +19,7 @@ namespace Queue\Test\TestCase\Command;
 use Cake\Core\Configure;
 use Cake\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\TestSuite\TestCase;
+use TestApp\WelcomeMailerListener;
 
 /**
  * Class WorkerCommandTest
@@ -60,5 +61,42 @@ class WorkerCommandTest extends TestCase
         ]);
         $this->exec('worker --max-runtime=1');
         $this->assertEmpty($this->getActualOutput());
+    }
+    /**
+     * Test that queue will run for one second with valid listener
+     * @runInSeparateProcess
+     */
+    public function testQueueProcessesWithListener()
+    {
+        Configure::write(['Queue' => [
+            'default' => [
+                'queue' => 'default',
+                'url' => 'null:',
+                'listener' => WelcomeMailerListener::class
+            ]
+        ]
+        ]);
+        $this->exec('worker --max-runtime=1');
+        $this->assertEmpty($this->getActualOutput());
+    }
+
+    /**
+     * Test that queue will abort with invalid listener
+     *
+     * @runInSeparateProcess
+     */
+    public function testQueueProcessesWithInvalidListener()
+    {
+        Configure::write(['Queue' => [
+            'default' => [
+                'queue' => 'default',
+                'url' => 'null:',
+                'listener' => 'InvalidListener',
+            ]
+        ]
+        ]);
+
+        $out = $this->exec('worker --max-runtime=1');
+        $this->assertErrorContains('Listener class InvalidListener not found');
     }
 }

--- a/tests/TestCase/Command/WorkerCommandTest.php
+++ b/tests/TestCase/Command/WorkerCommandTest.php
@@ -103,7 +103,6 @@ class WorkerCommandTest extends TestCase
         $this->assertErrorContains('Configuration key "invalid_config" was not found');
     }
 
-
     /**
      * Test that queue will abort with invalid listener
      *

--- a/tests/TestCase/Command/WorkerCommandTest.php
+++ b/tests/TestCase/Command/WorkerCommandTest.php
@@ -84,7 +84,7 @@ class WorkerCommandTest extends TestCase
     }
 
     /**
-     * Test that queue will abort with invalid listener
+     * Test that queue will abort when the passed config is not present in the app configuration.
      *
      * @runInSeparateProcess
      */

--- a/tests/TestCase/Command/WorkerCommandTest.php
+++ b/tests/TestCase/Command/WorkerCommandTest.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         0.1.0
+ * @license       https://opensource.org/licenses/MIT MIT License
+ */
+namespace Queue\Test\TestCase\Command;
+
+use Cake\Core\Configure;
+use Cake\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * Class WorkerCommandTest
+ * @package Queue\Test\TestCase\Command
+ */
+class WorkerCommandTest extends TestCase
+{
+    use ConsoleIntegrationTestTrait;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->useCommandRunner();
+    }
+
+    /**
+     * Test that command description prints out
+     */
+    public function testDescriptionOutput()
+    {
+        $this->exec('worker --help');
+        $this->assertOutputContains('Runs a queue worker');
+    }
+
+    /**
+     * Test that queue will run for one second
+     */
+    public function testQueueProcessesStart()
+    {
+        Configure::write(['Queue' => [
+                'default' => [
+                    'queue' => 'default',
+                    'url' => 'null:',
+                ]
+            ]
+        ]);
+        $this->exec('worker --max-runtime=1');
+        $this->assertEmpty($this->getActualOutput());
+    }
+}

--- a/tests/TestCase/Command/WorkerCommandTest.php
+++ b/tests/TestCase/Command/WorkerCommandTest.php
@@ -74,7 +74,7 @@ class WorkerCommandTest extends TestCase
             'default' => [
                 'queue' => 'default',
                 'url' => 'null:',
-                'listener' => WelcomeMailerListener::class
+                'listener' => WelcomeMailerListener::class,
             ],
         ],
         ]);

--- a/tests/TestCase/Command/WorkerCommandTest.php
+++ b/tests/TestCase/Command/WorkerCommandTest.php
@@ -45,6 +45,7 @@ class WorkerCommandTest extends TestCase
 
     /**
      * Test that queue will run for one second
+     * @runInSeparateProcess
      */
     public function testQueueProcessesStart()
     {

--- a/tests/TestCase/Command/WorkerCommandTest.php
+++ b/tests/TestCase/Command/WorkerCommandTest.php
@@ -62,8 +62,10 @@ class WorkerCommandTest extends TestCase
         $this->exec('worker --max-runtime=1');
         $this->assertEmpty($this->getActualOutput());
     }
+
     /**
      * Test that queue will run for one second with valid listener
+     *
      * @runInSeparateProcess
      */
     public function testQueueProcessesWithListener()
@@ -73,8 +75,8 @@ class WorkerCommandTest extends TestCase
                 'queue' => 'default',
                 'url' => 'null:',
                 'listener' => WelcomeMailerListener::class
-            ]
-        ]
+            ],
+        ],
         ]);
         $this->exec('worker --max-runtime=1');
         $this->assertEmpty($this->getActualOutput());
@@ -92,11 +94,11 @@ class WorkerCommandTest extends TestCase
                 'queue' => 'default',
                 'url' => 'null:',
                 'listener' => 'InvalidListener',
-            ]
-        ]
+            ],
+        ],
         ]);
 
-        $out = $this->exec('worker --max-runtime=1');
+        $this->exec('worker --max-runtime=1');
         $this->assertErrorContains('Listener class InvalidListener not found');
     }
 }

--- a/tests/TestCase/Command/WorkerCommandTest.php
+++ b/tests/TestCase/Command/WorkerCommandTest.php
@@ -18,7 +18,6 @@ namespace Queue\Test\TestCase\Command;
 
 use Cake\Core\Configure;
 use Cake\Log\Log;
-use Cake\Queue\QueueManager;
 use Cake\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 use TestApp\WelcomeMailerListener;

--- a/tests/TestCase/Command/WorkerCommandTest.php
+++ b/tests/TestCase/Command/WorkerCommandTest.php
@@ -88,6 +88,27 @@ class WorkerCommandTest extends TestCase
      *
      * @runInSeparateProcess
      */
+    public function testQueueWillAbortWithMissingConfig()
+    {
+        Configure::write(['Queue' => [
+            'default' => [
+                'queue' => 'default',
+                'url' => 'null:',
+                'listener' => 'InvalidListener',
+            ],
+        ],
+        ]);
+
+        $this->exec('worker --config=invalid_config --max-runtime=1');
+        $this->assertErrorContains('Configuration key "invalid_config" was not found');
+    }
+
+
+    /**
+     * Test that queue will abort with invalid listener
+     *
+     * @runInSeparateProcess
+     */
     public function testQueueProcessesWithInvalidListener()
     {
         Configure::write(['Queue' => [

--- a/tests/TestCase/Command/WorkerCommandTest.php
+++ b/tests/TestCase/Command/WorkerCommandTest.php
@@ -105,7 +105,7 @@ class WorkerCommandTest extends TestCase
     }
 
     /**
-     * Test that queue will abort with logger option
+     * Test that queue will write to specified logger option
      *
      * @runInSeparateProcess
      */

--- a/tests/TestCase/Command/WorkerCommandTest.php
+++ b/tests/TestCase/Command/WorkerCommandTest.php
@@ -22,6 +22,7 @@ use Cake\TestSuite\TestCase;
 
 /**
  * Class WorkerCommandTest
+ *
  * @package Queue\Test\TestCase\Command
  */
 class WorkerCommandTest extends TestCase
@@ -45,6 +46,7 @@ class WorkerCommandTest extends TestCase
 
     /**
      * Test that queue will run for one second
+     *
      * @runInSeparateProcess
      */
     public function testQueueProcessesStart()
@@ -53,8 +55,8 @@ class WorkerCommandTest extends TestCase
                 'default' => [
                     'queue' => 'default',
                     'url' => 'null:',
-                ]
-            ]
+                ],
+            ],
         ]);
         $this->exec('worker --max-runtime=1');
         $this->assertEmpty($this->getActualOutput());

--- a/tests/TestCase/Mailer/QueueTraitTest.php
+++ b/tests/TestCase/Mailer/QueueTraitTest.php
@@ -50,7 +50,7 @@ class QueueTraitTest extends TestCase
 
     /**
      * Test that QueueTrait calls push
-     *
+     * @runInSeparateProcess
      * @return @void
      */
     public function testQueueTraitCallsPush()

--- a/tests/TestCase/Mailer/QueueTraitTest.php
+++ b/tests/TestCase/Mailer/QueueTraitTest.php
@@ -50,6 +50,7 @@ class QueueTraitTest extends TestCase
 
     /**
      * Test that QueueTrait calls push
+     *
      * @runInSeparateProcess
      * @return @void
      */

--- a/tests/app/TestApp/WelcomeMailerListener.php
+++ b/tests/app/TestApp/WelcomeMailerListener.php
@@ -20,6 +20,7 @@ use Cake\Event\EventListenerInterface;
 
 /**
  * Class WelcomeMailerListener
+ *
  * @package Queue\Test\test_app\App\Listener
  */
 class WelcomeMailerListener implements EventListenerInterface
@@ -31,5 +32,4 @@ class WelcomeMailerListener implements EventListenerInterface
     {
         return [];
     }
-
 }

--- a/tests/app/TestApp/WelcomeMailerListener.php
+++ b/tests/app/TestApp/WelcomeMailerListener.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         0.1.0
+ * @license       https://opensource.org/licenses/MIT MIT License
+ */
+namespace TestApp;
+
+use Cake\Event\EventListenerInterface;
+
+/**
+ * Class WelcomeMailerListener
+ * @package Queue\Test\test_app\App\Listener
+ */
+class WelcomeMailerListener implements EventListenerInterface
+{
+    /**
+     * @return array
+     */
+    public function implementedEvents(): array
+    {
+        return [];
+    }
+
+}


### PR DESCRIPTION
This PR moves the Shell to a Command class. It also cleans up a few issues. 

I had  some test that pass individually but not in the suite. This is because of the statics found on line 91-98 of QueueManager. I can't change the configuration for different testing scenarios. So many statics in this library. Do these restrictions in the QueueManager need to remain? Can here be a static reset in the QueueManager so these things can be tested? For now I'm just running them in separate processes.

Also, there is an option called "config" that is meant to be an array? It passes the listener. My guess is that should come from the config like the "url". Is that right?