### PR TITLE
Add support for setting the processor name in the Cli option.

### DIFF
--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -119,7 +119,6 @@ class WorkerCommand extends Command
     {
         $logger = $this->getLogger($args);
         $processor = new Processor($logger);
-        $processorName = $args->getOption('processor') ? (string)$args->getOption('processor') : null;
         $extension = $this->getQueueExtension($args, $logger);
 
         $config = (string)$args->getOption('config');
@@ -143,7 +142,8 @@ class WorkerCommand extends Command
         }
         $url = Configure::read(sprintf('Queue.%s.url', $config));
         $client = new SimpleClient($url, $logger);
-        $client->bindTopic((string)$args->getOption('queue'), $processor, $processorName);
+        /** @psalm-suppress InvalidArgument */
+        $client->bindTopic((string)$args->getOption('queue'), $processor, $args->getOption('processor'));
         $client->consume($extension);
     }
 }

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -119,7 +119,6 @@ class WorkerCommand extends Command
     {
         $logger = $this->getLogger($args);
         $processor = new Processor($logger);
-        $processorName = (string)$args->getOption('processor');
         $extension = $this->getQueueExtension($args, $logger);
 
         $config = (string)$args->getOption('config');
@@ -143,7 +142,7 @@ class WorkerCommand extends Command
         }
         $url = Configure::read(sprintf('Queue.%s.url', $config));
         $client = new SimpleClient($url, $logger);
-        $client->bindTopic((string)$args->getOption('queue'), $processor, $processorName);
+        $client->bindTopic((string)$args->getOption('queue'), $processor, $args->getOption('processor'));
         $client->consume($extension);
     }
 }

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -119,6 +119,7 @@ class WorkerCommand extends Command
     {
         $logger = $this->getLogger($args);
         $processor = new Processor($logger);
+        $processorName = $args->getOption('processor') ? (string)$args->getOption('processor') : null;
         $extension = $this->getQueueExtension($args, $logger);
 
         $config = (string)$args->getOption('config');
@@ -142,7 +143,7 @@ class WorkerCommand extends Command
         }
         $url = Configure::read(sprintf('Queue.%s.url', $config));
         $client = new SimpleClient($url, $logger);
-        $client->bindTopic((string)$args->getOption('queue'), $processor, $args->getOption('processor'));
+        $client->bindTopic((string)$args->getOption('queue'), $processor, $processorName);
         $client->consume($extension);
     }
 }

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -52,6 +52,11 @@ class WorkerCommand extends Command
             'help' => 'Name of queue to bind to',
             'short' => 'Q',
         ]);
+        $parser->addOption('processor', [
+            'help' => 'Name of processor to bind to',
+            'default' => null,
+            'short' => 'p',
+        ]);
         $parser->addOption('logger', [
             'help' => 'Name of a configured logger',
             'default' => 'stdout',
@@ -114,6 +119,7 @@ class WorkerCommand extends Command
     {
         $logger = $this->getLogger($args);
         $processor = new Processor($logger);
+        $processorName = (string)$args->getOption('processor');
         $extension = $this->getQueueExtension($args, $logger);
 
         $config = (string)$args->getOption('config');
@@ -137,7 +143,7 @@ class WorkerCommand extends Command
         }
         $url = Configure::read(sprintf('Queue.%s.url', $config));
         $client = new SimpleClient($url, $logger);
-        $client->bindTopic((string)$args->getOption('queue'), $processor);
+        $client->bindTopic((string)$args->getOption('queue'), $processor, $processorName);
         $client->consume($extension);
     }
 }

--- a/tests/TestCase/Command/WorkerCommandTest.php
+++ b/tests/TestCase/Command/WorkerCommandTest.php
@@ -86,24 +86,6 @@ class WorkerCommandTest extends TestCase
     }
 
     /**
-     * Test that queue will run by setting the processor name
-     *
-     * @runInSeparateProcess
-     */
-    public function testQueueProcessesWithProcessor()
-    {
-        Configure::write(['Queue' => [
-            'default' => [
-                'queue' => 'default',
-                'url' => 'null:',
-            ],
-        ],
-        ]);
-        $this->exec('worker --max-runtime=1 --processor=processor-name');
-        $this->assertEmpty($this->getActualOutput());
-    }
-
-    /**
      * Test that queue will abort when the passed config is not present in the app configuration.
      *
      * @runInSeparateProcess


### PR DESCRIPTION
This is a pull request for the following issue.
https://github.com/cakephp/queue/issues/50

Updated the Cli option to allow specifying the processor name.
（This is my first pull request, so I apologize if this is incorrect.）