### PR TITLE
Fix worker compatibility in PHP8

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,29 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     colors="true"
     bootstrap="tests/bootstrap.php"
-    >
-
-    <testsuites>
-        <testsuite name="queue">
-            <directory>tests/TestCase</directory>
-        </testsuite>
-    </testsuites>
-
-    <!-- Setup a listener for fixtures -->
-    <listeners>
-        <listener class="Cake\TestSuite\Fixture\FixtureInjector">
-            <arguments>
-                <object class="Cake\TestSuite\Fixture\FixtureManager"/>
-            </arguments>
-        </listener>
-    </listeners>
-
-    <!-- Prevent coverage reports from looking in tests, vendors, config folders -->
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <!-- Only collect coverage for src/ -->
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="queue">
+      <directory>tests/TestCase</directory>
+    </testsuite>
+  </testsuites>
+  <!-- Setup a listener for fixtures -->
+  <listeners>
+    <listener class="Cake\TestSuite\Fixture\FixtureInjector">
+      <arguments>
+        <object class="Cake\TestSuite\Fixture\FixtureManager"/>
+      </arguments>
+    </listener>
+  </listeners>
 </phpunit>

--- a/src/Job/Message.php
+++ b/src/Job/Message.php
@@ -17,9 +17,11 @@ declare(strict_types=1);
 namespace Cake\Queue\Job;
 
 use Cake\Utility\Hash;
+use Closure;
 use Interop\Queue\Context;
 use Interop\Queue\Message as QueueMessage;
 use JsonSerializable;
+use RuntimeException;
 
 class Message implements JsonSerializable
 {
@@ -37,6 +39,11 @@ class Message implements JsonSerializable
      * @var array
      */
     protected $parsedBody;
+
+    /**
+     * @var callable|null
+     */
+    protected $callable;
 
     /**
      * @param \Interop\Queue\Message $originalMessage Queue message.
@@ -74,11 +81,36 @@ class Message implements JsonSerializable
     }
 
     /**
-     * @return mixed
+     * Get a closure containing the callable in the job.
+     *
+     * Supported callables include:
+     *
+     * - strings for global functions, or static method names.
+     * - array of [class, method]. The class will be constructed with no constructor parameters.
+     *
+     * @return \Closure
      */
     public function getCallable()
     {
-        return $this->parsedBody['class'] ?? null;
+        if ($this->callable) {
+            return $this->callable;
+        }
+        $target = $this->parsedBody['class'] ?? null;
+
+        $callable = null;
+        if (is_array($target) && count($target) == 2) {
+            $instance = new $target[0]();
+            $callable = Closure::fromCallable([$instance, $target[1]]);
+        } elseif (is_string($target)) {
+            /** @psalm-suppress InvalidArgument */
+            $callable = Closure::fromCallable($target);
+        }
+        if (!isset($callable)) {
+            throw new RuntimeException(sprintf('Could not create callable from `%s`', json_encode($target)));
+        }
+        $this->callable = $callable;
+
+        return $this->callable;
     }
 
     /**


### PR DESCRIPTION
In php8 `is_callable()` no longer accepts non static methods in a static
context. This makes our checks for instance methods fail causing workers
to never actually process jobs.

By moving the callable creation into the Message class we can give
better errors and have a better separation of concerns, and fix the
PHP8 issue. This shouldn't cause cross release job failures as the
message wire format has not changed.

Fixes #55