### PR TITLE
added support for simply using different queue than default

### DIFF
--- a/src/QueueManager.php
+++ b/src/QueueManager.php
@@ -98,19 +98,18 @@ class QueueManager
             throw new BadMethodCallException('Must specify `url` key.');
         }
         
-        if(isset($config['queue']) && !empty($config['queue'])) {
-            if(!is_array($config['url'])) {
+        if (isset($config['queue']) && !empty($config['queue'])) {
+            if (!is_array($config['url'])) {
                 $config['url'] = [
                     'transport' => $config['url'],
                     'client' => [
                         'router_topic' => $config['queue'],
                         'router_queue' => $config['queue'],
                         'default_queue' => $config['queue'],
-                    ]
+                    ],
                 ];
-            }
-            else {
-                $clientConfig = isset($config['url']['client']) ? $config['url']['client'] : [];
+            } else {
+                $clientConfig = $config['url']['client'] ?? [];
                 $config['url']['client'] = $clientConfig + [
                     'router_topic' => $config['queue'],
                     'router_queue' => $config['queue'],
@@ -118,7 +117,7 @@ class QueueManager
                 ];
             }
         }
-
+        
         /** @psalm-suppress InvalidPropertyAssignmentValue */
         static::$_config[$key] = $config;
     }

--- a/src/QueueManager.php
+++ b/src/QueueManager.php
@@ -97,6 +97,27 @@ class QueueManager
         if (empty($config['url'])) {
             throw new BadMethodCallException('Must specify `url` key.');
         }
+        
+        if(isset($config['queue']) && !empty($config['queue'])) {
+            if(!is_array($config['url'])) {
+                $config['url'] = [
+                    'transport' => $config['url'],
+                    'client' => [
+                        'router_topic' => $config['queue'],
+                        'router_queue' => $config['queue'],
+                        'default_queue' => $config['queue'],
+                    ]
+                ];
+            }
+            else {
+                $clientConfig = isset($config['url']['client']) ? $config['url']['client'] : [];
+                $config['url']['client'] = $clientConfig + [
+                    'router_topic' => $config['queue'],
+                    'router_queue' => $config['queue'],
+                    'default_queue' => $config['queue'],
+                ];
+            }
+        }
 
         /** @psalm-suppress InvalidPropertyAssignmentValue */
         static::$_config[$key] = $config;

--- a/src/QueueManager.php
+++ b/src/QueueManager.php
@@ -97,8 +97,8 @@ class QueueManager
         if (empty($config['url'])) {
             throw new BadMethodCallException('Must specify `url` key.');
         }
-        
-        if (isset($config['queue']) && !empty($config['queue'])) {
+
+        if (!empty($config['queue'])) {
             if (!is_array($config['url'])) {
                 $config['url'] = [
                     'transport' => $config['url'],
@@ -117,7 +117,7 @@ class QueueManager
                 ];
             }
         }
-        
+
         /** @psalm-suppress InvalidPropertyAssignmentValue */
         static::$_config[$key] = $config;
     }


### PR DESCRIPTION
edited QueueManager

if the config url key is a string, will be converted to array and all the client config will be setted.
if the config url key is an array, the client config will be merged