### PR TITLE
Fix queue parameter being required on non-default queues 

### DIFF
--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -48,8 +48,7 @@ class WorkerCommand extends Command
             'short' => 'c',
         ]);
         $parser->addOption('queue', [
-            'default' => 'default',
-            'help' => 'Name of queue to bind to',
+            'help' => 'Name of queue to bind to. Defaults to the queue config (--config).',
             'short' => 'Q',
         ]);
         $parser->addOption('processor', [
@@ -140,10 +139,11 @@ class WorkerCommand extends Command
             $processor->getEventManager()->on($listener);
             $extension->getEventManager()->on($listener);
         }
-        $url = Configure::read(sprintf('Queue.%s.url', $config));
+        $url = Configure::read("Queue.{$config}.url");
         $client = new SimpleClient($url, $logger);
-        /** @psalm-suppress InvalidArgument */
-        $client->bindTopic((string)$args->getOption('queue'), $processor, $args->getOption('processor'));
+        $queue = $args->getOption('queue') ?? Configure::read("Queue.{$config}.queue") ?? 'default';
+
+        $client->bindTopic($queue, $processor, $args->getOption('processor'));
         $client->consume($extension);
     }
 }


### PR DESCRIPTION
When the queue name is not 'default' you effectively had to provide both the `--config` and `--queue` options. We should be treating the CLI flag as an override for what is in the `--config`.

I also fixed the tests as they weren't really checking anything and would always pass.

Fixes #60