### PR TITLE
Don't set Queue configuration multiple times

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,8 +16,4 @@
       <directory>tests/TestCase</directory>
     </testsuite>
   </testsuites>
-
-  <extensions>
-    <extension class="Cake\TestSuite\Fixture\PHPUnitExtension" />
-  </extensions>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,22 +5,19 @@
     bootstrap="tests/bootstrap.php"
     xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <!-- Only collect coverage for src/ -->
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </coverage>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./src/</directory>
+    </whitelist>
+  </filter>
+
   <testsuites>
     <testsuite name="queue">
       <directory>tests/TestCase</directory>
     </testsuite>
   </testsuites>
-  <!-- Setup a listener for fixtures -->
-  <listeners>
-    <listener class="Cake\TestSuite\Fixture\FixtureInjector">
-      <arguments>
-        <object class="Cake\TestSuite\Fixture\FixtureManager"/>
-      </arguments>
-    </listener>
-  </listeners>
+
+  <extensions>
+    <extension class="Cake\TestSuite\Fixture\PHPUnitExtension" />
+  </extensions>
 </phpunit>

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -49,7 +49,11 @@ class Plugin extends BasePlugin
      */
     public function bootstrap(PluginApplicationInterface $app): void
     {
-        QueueManager::setConfig(Configure::read('Queue'));
+        foreach (Configure::read('Queue') as $key => $data) {
+            if (QueueManager::getConfig($key) === null) {
+                QueueManager::setConfig($key, $data);
+            }
+        }
     }
 
     /**

--- a/tests/TestCase/Command/WorkerCommandTest.php
+++ b/tests/TestCase/Command/WorkerCommandTest.php
@@ -136,7 +136,7 @@ class WorkerCommandTest extends TestCase
             'Queue' => [
                 'default' => [
                         'queue' => 'default',
-                        'url' => 'null:',
+                        'url' => 'file:///' . TMP . DS . 'queue',
                     ],
                 ],
         ]);
@@ -146,7 +146,7 @@ class WorkerCommandTest extends TestCase
         ]);
 
         $this->exec('worker --max-runtime=1 --logger=debug --verbose');
-        $this->assertDebugLogContains('debug Max Iterations: 0');
+        $this->assertDebugLogContains('debug: Max Iterations: 0');
     }
 
     /**

--- a/tests/TestCase/Command/WorkerCommandTest.php
+++ b/tests/TestCase/Command/WorkerCommandTest.php
@@ -146,7 +146,7 @@ class WorkerCommandTest extends TestCase
         ]);
 
         $this->exec('worker --max-runtime=1 --logger=debug --verbose');
-        $this->assertDebugLogContains('debug: Max Iterations: 0');
+        $this->assertDebugLogContains('Max Iterations: 0');
     }
 
     /**


### PR DESCRIPTION
Only set configuration data once. This is relevant when integration tests are used and bootstrap() is called multiple times.

Fixes #67