### PR TITLE
Fix jsonSerialize Deprecation Notice

### DIFF
--- a/src/Job/Message.php
+++ b/src/Job/Message.php
@@ -138,6 +138,7 @@ class Message implements JsonSerializable
     /**
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->parsedBody;


### PR DESCRIPTION
This fixes the notice I get when running the queue worker on PHP 8.1.

> Notice: Deprecated (8192): Return type of Cake\Queue\Job\Message::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice