### PR TITLE
Minor Test Cleanup

### DIFF
--- a/tests/TestCase/Job/MailerJobTest.php
+++ b/tests/TestCase/Job/MailerJobTest.php
@@ -50,11 +50,11 @@ class MailerJobTest extends TestCase
         $this->args = ['username' => 'joe.doe', 'first_name' => 'Joe', 'last_name' => 'Doe'];
 
         $this->mailer = $this->getMockBuilder(Mailer::class)
-            ->setMethods(['send'])
+            ->onlyMethods(['send'])
             ->getMock();
 
         $this->job = $this->getMockBuilder(MailerJob::class)
-            ->setMethods(['getMailer'])
+            ->onlyMethods(['getMailer'])
             ->getMock();
     }
 

--- a/tests/TestCase/Job/MailerJobTest.php
+++ b/tests/TestCase/Job/MailerJobTest.php
@@ -32,7 +32,7 @@ class MailerJobTest extends TestCase
      */
     protected $mailer;
     /**
-     * @var Cake\Queue\Job\MailerJob|\PHPUnit\Framework\MockObject\MockObject
+     * @var \Cake\Queue\Job\MailerJob|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $job;
     protected $mailerConfig;
@@ -139,7 +139,7 @@ class MailerJobTest extends TestCase
     /**
      * Create a simple message for testing.
      *
-     * @return \Queue\Job\Message
+     * @return \Cake\Queue\Job\Message
      */
     protected function createMessage(): Message
     {

--- a/tests/TestCase/Queue/ProcessorTest.php
+++ b/tests/TestCase/Queue/ProcessorTest.php
@@ -254,7 +254,7 @@ class ProcessorTest extends TestCase
     /**
      * Job to be used in test testProcessMessageCallableIsString
      *
-     * @param \Queue\Queue\Message $message The message to process
+     * @param \Cake\Queue\Message $message The message to process
      * @return null
      */
     public static function processReturnReject(Message $message)
@@ -267,7 +267,7 @@ class ProcessorTest extends TestCase
     /**
      * Job to be used in test testProcessMessageCallableIsString
      *
-     * @param \Queue\Queue\Message $message The message to process
+     * @param \Cake\Queue\Message $message The message to process
      * @return null
      */
     public static function processReturnAck(Message $message)
@@ -280,7 +280,7 @@ class ProcessorTest extends TestCase
     /**
      * Job to be used in test testProcessMessageCallableIsString
      *
-     * @param \Queue\Queue\Message $message The message to process
+     * @param \Cake\Queue\Message $message The message to process
      * @return null
      */
     public static function processReturnRequeue(Message $message)
@@ -293,7 +293,7 @@ class ProcessorTest extends TestCase
     /**
      * Job to be used in test testProcessMessageCallableIsString
      *
-     * @param \Queue\Queue\Message $message The message to process
+     * @param \Cake\Queue\Message $message The message to process
      * @return null
      */
     public static function processReturnString(Message $message)


### PR DESCRIPTION
- Remove deprecated `setMethods` PHPUnit Mock calls in favor of `onlyMethods`
- Fix doc blocks classes