### PR TITLE
Change QueueManager::push to Only Accept Job Classes

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -126,18 +126,17 @@ Queue the messages using the included `Queue\QueueManager` class::
     use App\Job\ExampleJob;
     use Cake\Queue\QueueManager;
 
-    $callable = [ExampleJob::class, 'execute'];
     $data = ['id' => 7, 'is_premium' => true];
     $options = ['config' => 'default'];
 
-    QueueManager::push($callable, $data, $options);
+    QueueManager::push(ExampleJob::class, $data, $options);
 
 Arguments:
 
-- ``$callable``: A callable that will be invoked. This callable **must** be valid
-  within the context of your application. Job classes are prefered.
-- ``$data`` (optional): A json-serializable array of data that will be passed to
-  the job via message. It should be key-value pairs.
+- ``$className``: The class that will have it's execute method invoked when the
+  job is processed.
+- ``$data`` (optional): A json-serializable array of data that will be
+  passed to your job as a message. It should be key-value pairs.
 - ``$options`` (optional): An array of optional data for message queueing.
 
 The following keys are valid for use within the ``options`` array:

--- a/src/Mailer/QueueTrait.php
+++ b/src/Mailer/QueueTrait.php
@@ -44,7 +44,7 @@ trait QueueTrait
             ]);
         }
 
-        QueueManager::push([MailerJob::class, 'execute'], [
+        QueueManager::push(MailerJob::class, [
             'mailerConfig' => $options['mailerConfig'] ?? null,
             'mailerName' => static::class,
             'action' => $action,

--- a/tests/TestCase/Command/WorkerCommandTest.php
+++ b/tests/TestCase/Command/WorkerCommandTest.php
@@ -153,7 +153,7 @@ class WorkerCommandTest extends TestCase
         $config = [
             'queue' => 'default',
             'url' => 'file:///' . TMP . DS . 'queue',
-            'receiveTimeout' => 1,
+            'receiveTimeout' => 100,
         ];
         Configure::write('Queue', ['default' => $config]);
 
@@ -185,7 +185,7 @@ class WorkerCommandTest extends TestCase
         $config = [
             'queue' => 'default',
             'url' => 'file:///' . TMP . DS . 'queue',
-            'receiveTimeout' => 1,
+            'receiveTimeout' => 100,
         ];
         Configure::write('Queue', ['default' => $config]);
         Log::setConfig('debug', [
@@ -216,7 +216,7 @@ class WorkerCommandTest extends TestCase
         $config = [
             'queue' => 'other',
             'url' => 'file:///' . TMP . DS . 'other-queue',
-            'receiveTimeout' => 1,
+            'receiveTimeout' => 100,
         ];
         Configure::write('Queue', ['other' => $config]);
 

--- a/tests/TestCase/QueueManagerTest.php
+++ b/tests/TestCase/QueueManagerTest.php
@@ -113,7 +113,7 @@ class QueueManagerTest extends TestCase
     public function testPushInvalidClass()
     {
         $this->expectException('\InvalidArgumentException');
-        $this->expectExceptionMessage('Invalid callable provided.');
-        QueueManager::push(['Nope', 'lol']);
+        $this->expectExceptionMessage('class does not exist.');
+        QueueManager::push('NotARealJob');
     }
 }

--- a/tests/test_app/src/Job/LogToDebugJob.php
+++ b/tests/test_app/src/Job/LogToDebugJob.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Job;
+
+use Cake\Log\Log;
+use Cake\Queue\Job\JobInterface;
+use Cake\Queue\Job\Message;
+use Interop\Queue\Processor;
+
+class LogToDebugJob implements JobInterface
+{
+    public function execute(Message $message): ?string
+    {
+        Log::debug('Debug job was run');
+
+        return Processor::ACK;
+    }
+}


### PR DESCRIPTION
This will make the code in projects that use the queue much cleaner. Instead of having to pass `[Job::class, 'execute']` everywhere the user will be able to pass `Job::class` directly  and the `'execute'` portion will be added automatically.

Closes #78