### PR TITLE
Flatten Arguments in Queue Payload

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -127,17 +127,17 @@ Queue the messages using the included `Queue\QueueManager` class::
     use Cake\Queue\QueueManager;
 
     $callable = [ExampleJob::class, 'execute'];
-    $arguments = ['id' => 7, 'data' => 'hi2u'];
+    $data = ['id' => 7, 'is_premium' => true];
     $options = ['config' => 'default'];
 
-    QueueManager::push($callable, $arguments, $options);
+    QueueManager::push($callable, $data, $options);
 
 Arguments:
 
 - ``$callable``: A callable that will be invoked. This callable **must** be valid
   within the context of your application. Job classes are prefered.
-- ``$arguments`` (optional): A json-serializable array of data that is to be
-  made present for your message. It should be key-value pairs.
+- ``$data`` (optional): A json-serializable array of data that will be passed to
+  the job via message. It should be key-value pairs.
 - ``$options`` (optional): An array of optional data for message queueing.
 
 The following keys are valid for use within the ``options`` array:

--- a/src/Job/Message.php
+++ b/src/Job/Message.php
@@ -119,11 +119,18 @@ class Message implements JsonSerializable
      */
     public function getArgument($key = null, $default = null)
     {
-        if ($key === null) {
-            return $this->parsedBody['args'][0];
+        if (array_key_exists('data', $this->parsedBody)) {
+            $data = $this->parsedBody['data'];
+        } else {
+            // support old jobs that still use args key
+            $data = $this->parsedBody['args'][0];
         }
 
-        return Hash::get($this->parsedBody['args'][0], $key, $default);
+        if ($key === null) {
+            return $data;
+        }
+
+        return Hash::get($data, $key, $default);
     }
 
     /**

--- a/src/QueueManager.php
+++ b/src/QueueManager.php
@@ -180,7 +180,7 @@ class QueueManager
      *   to a statically callable function. When an array is used, the
      *   class will be constructed by Queue\Processor and have the
      *   named method invoked.
-     * @param array $args An array of data to set for the job.
+     * @param array $data An array of data that will be passed to the job.
      * @param array $options An array of options for publishing the job:
      *   - `config` - A queue config name. Defaults to 'default'.
      *   - `delay` - Time (in integer seconds) to delay message, after which it
@@ -198,7 +198,7 @@ class QueueManager
      *      string 'default' if empty.
      * @return void
      */
-    public static function push($callable, array $args = [], array $options = []): void
+    public static function push($callable, array $data = [], array $options = []): void
     {
         // We can't use the callable type as it checks that the
         // [class, method] is statically callable which won't be true.
@@ -223,7 +223,8 @@ class QueueManager
         $message = new ClientMessage([
             'queue' => $queue,
             'class' => $callable,
-            'args' => [$args],
+            'args' => [$data],
+            'data' => $data,
         ]);
 
         if ($options['delay']) {

--- a/tests/TestCase/Job/MailerJobTest.php
+++ b/tests/TestCase/Job/MailerJobTest.php
@@ -146,14 +146,12 @@ class MailerJobTest extends TestCase
         $messageBody = [
             'queue' => 'default',
             'class' => ['Queue\\Job\\EventJob', 'execute'],
-            'args' => [
-                [
-                    'mailerName' => 'SampleTest',
-                    'mailerConfig' => $this->mailerConfig,
-                    'action' => 'welcome',
-                    'args' => $this->args,
-                    'headers' => $this->headers,
-                ],
+            'data' => [
+                'mailerName' => 'SampleTest',
+                'mailerConfig' => $this->mailerConfig,
+                'action' => 'welcome',
+                'args' => $this->args,
+                'headers' => $this->headers,
             ],
         ];
         $connectionFactory = new NullConnectionFactory();

--- a/tests/TestCase/Queue/ProcessorTest.php
+++ b/tests/TestCase/Queue/ProcessorTest.php
@@ -107,11 +107,7 @@ class ProcessorTest extends TestCase
         $messageBody = [
             'queue' => 'default',
             'class' => ['NotValid\\ClassName\\FakeJob', 'execute'],
-            'args' => [
-                [
-                    'data' => ['sample_data' => 'a value'],
-                ],
-            ],
+            'data' => ['sample_data' => 'a value'],
         ];
         $connectionFactory = new NullConnectionFactory();
         $context = $connectionFactory->createContext();
@@ -148,11 +144,7 @@ class ProcessorTest extends TestCase
         $messageBody = [
             'queue' => 'default',
             'class' => [static::class, $method],
-            'args' => [
-                [
-                    'data' => ['sample_data' => 'a value', 'key' => md5($method)],
-                ],
-            ],
+            'data' => ['sample_data' => 'a value', 'key' => md5($method)],
         ];
         $connectionFactory = new NullConnectionFactory();
         $context = $connectionFactory->createContext();
@@ -330,11 +322,7 @@ class ProcessorTest extends TestCase
         $messageBody = [
             'queue' => 'default',
             'class' => static::class . '::' . $method,
-            'args' => [
-                [
-                    'data' => ['sample_data' => 'a value', 'key' => md5($method)],
-                ],
-            ],
+            'data' => ['sample_data' => 'a value', 'key' => md5($method)],
         ];
         $connectionFactory = new NullConnectionFactory();
         $context = $connectionFactory->createContext();


### PR DESCRIPTION
We store arguments on the queue as an array, but there is only ever one element in that array. I can't think of a reason to have an array with only one element in it.

Old Structure:
```json
{"queue":"default","class":["App\\Job\\HelloJob","execute"],"args":[{"name":"World","number":1,"bool":true}]}
```

New Structure:
```json
{"queue":"default","class":["App\\Job\\HelloJob","execute"],"data":{"name":"World","number":1,"bool":true}}
```