### PR TITLE
Add failed jobs support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         }
     },
     "suggest": {
-        "cakephp/bake": "Required if you want to generate jobs."
+        "cakephp/bake": "Required if you want to generate jobs.",
+        "cakephp/migrations": "Needed for running the migrations necessary for using Failed Jobs."
     },
     "scripts": {
         "check": [

--- a/config/Migrations/20221007202459_CreateFailedJobs.php
+++ b/config/Migrations/20221007202459_CreateFailedJobs.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\AbstractMigration;
+
+class CreateFailedJobs extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('queue_failed_jobs');
+        $table->addColumn('class', 'string', [
+                'length' => 255,
+                'null' => false,
+                'default' => null,
+            ])
+            ->addColumn('method', 'string', [
+                'length' => 255,
+                'null' => false,
+                'default' => null,
+            ])
+            ->addColumn('data', 'text', [
+                'null' => false,
+                'default' => null,
+            ])
+            ->addColumn('config', 'string', [
+                'length' => 255,
+                'null' => false,
+                'default' => null,
+            ])
+            ->addColumn('priority', 'string', [
+                'length' => 255,
+                'null' => true,
+                'default' => null,
+            ])
+            ->addColumn('queue', 'string', [
+                'length' => 255,
+                'null' => false,
+                'default' => null,
+            ])
+            ->addColumn('exception', 'text', [
+                'null' => true,
+                'default' => null,
+            ])
+            ->addColumn('created', 'datetime', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->create();
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,4 +15,11 @@
       <directory>tests/TestCase</directory>
     </testsuite>
   </testsuites>
+  <listeners>
+    <listener class="Cake\TestSuite\Fixture\FixtureInjector">
+      <arguments>
+        <object class="Cake\TestSuite\Fixture\FixtureManager"/>
+      </arguments>
+    </listener>
+  </listeners>
 </phpunit>

--- a/src/Command/PurgeFailedCommand.php
+++ b/src/Command/PurgeFailedCommand.php
@@ -1,0 +1,128 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         0.1.0
+ * @license       https://opensource.org/licenses/MIT MIT License
+ */
+namespace Cake\Queue\Command;
+
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use Cake\ORM\Locator\LocatorAwareTrait;
+
+class PurgeFailedCommand extends Command
+{
+    use LocatorAwareTrait;
+
+    /**
+     * Get the command name.
+     *
+     * @return string
+     */
+    public static function defaultName(): string
+    {
+        return 'queue purge_failed';
+    }
+
+    /**
+     * Gets the option parser instance and configures it.
+     *
+     * @return \Cake\Console\ConsoleOptionParser
+     */
+    public function getOptionParser(): ConsoleOptionParser
+    {
+        $parser = parent::getOptionParser();
+
+        $parser->setDescription('Delete failed jobs.');
+
+        $parser->addArgument('ids', [
+            'required' => false,
+            'help' => 'Delete jobs by the FailedJob ID (comma-separated).',
+        ]);
+        $parser->addOption('class', [
+            'help' => 'Delete jobs by the job class.',
+        ]);
+        $parser->addOption('queue', [
+            'help' => 'Delete jobs by the queue the job was received on.',
+        ]);
+        $parser->addOption('config', [
+            'help' => 'Delete jobs by the config used to queue the job.',
+        ]);
+        $parser->addOption('force', [
+            'help' => 'Automatically assume yes in response to confirmation prompt.',
+            'short' => 'f',
+            'boolean' => true,
+        ]);
+
+        return $parser;
+    }
+
+    /**
+     * @param \Cake\Console\Arguments $args Arguments
+     * @param \Cake\Console\ConsoleIo $io ConsoleIo
+     * @return void
+     */
+    public function execute(Arguments $args, ConsoleIo $io)
+    {
+        /** @var \Cake\Queue\Model\Table\FailedJobsTable $failedJobsTable */
+        $failedJobsTable = $this->getTableLocator()->get('Cake/Queue.FailedJobs');
+
+        $jobsToDelete = $failedJobsTable->find();
+
+        if ($args->hasArgument('ids')) {
+            $idsArg = $args->getArgument('ids');
+
+            if ($idsArg !== null) {
+                $ids = explode(',', $idsArg);
+
+                $jobsToDelete->whereInList($failedJobsTable->aliasField('id'), $ids);
+            }
+        }
+
+        if ($args->hasOption('class')) {
+            $jobsToDelete->where(['class' => $args->getOption('class')]);
+        }
+
+        if ($args->hasOption('queue')) {
+            $jobsToDelete->where(['queue' => $args->getOption('queue')]);
+        }
+
+        if ($args->hasOption('config')) {
+            $jobsToDelete->where(['config' => $args->getOption('config')]);
+        }
+
+        $deletingCount = $jobsToDelete->count();
+
+        if (!$deletingCount) {
+            $io->out('0 jobs found.');
+
+            return;
+        }
+
+        if (!$args->getOption('force')) {
+            $confirmed = $io->askChoice("Delete {$deletingCount} jobs?", ['y', 'n'], 'n');
+
+            if ($confirmed !== 'y') {
+                return;
+            }
+        }
+
+        $io->out("Deleting {$deletingCount} jobs.");
+
+        $failedJobsTable->deleteManyOrFail($jobsToDelete);
+
+        $io->success("{$deletingCount} jobs deleted.");
+    }
+}

--- a/src/Command/RequeueCommand.php
+++ b/src/Command/RequeueCommand.php
@@ -1,0 +1,161 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         0.1.0
+ * @license       https://opensource.org/licenses/MIT MIT License
+ */
+namespace Cake\Queue\Command;
+
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+use Cake\ORM\Locator\LocatorAwareTrait;
+use Cake\Queue\QueueManager;
+use Exception;
+
+class RequeueCommand extends Command
+{
+    use LocatorAwareTrait;
+
+    /**
+     * Get the command name.
+     *
+     * @return string
+     */
+    public static function defaultName(): string
+    {
+        return 'queue requeue';
+    }
+
+    /**
+     * Gets the option parser instance and configures it.
+     *
+     * @return \Cake\Console\ConsoleOptionParser
+     */
+    public function getOptionParser(): ConsoleOptionParser
+    {
+        $parser = parent::getOptionParser();
+
+        $parser->setDescription('Requeue failed jobs.');
+
+        $parser->addArgument('ids', [
+            'required' => false,
+            'help' => 'Requeue jobs by the FailedJob ID (comma-separated).',
+        ]);
+        $parser->addOption('class', [
+            'help' => 'Requeue jobs by the job class.',
+        ]);
+        $parser->addOption('queue', [
+            'help' => 'Requeue jobs by the queue the job was received on.',
+        ]);
+        $parser->addOption('config', [
+            'help' => 'Requeue jobs by the config used to queue the job.',
+        ]);
+        $parser->addOption('force', [
+            'help' => 'Automatically assume yes in response to confirmation prompt.',
+            'short' => 'f',
+            'boolean' => true,
+        ]);
+
+        return $parser;
+    }
+
+    /**
+     * @param \Cake\Console\Arguments $args Arguments
+     * @param \Cake\Console\ConsoleIo $io ConsoleIo
+     * @return void
+     */
+    public function execute(Arguments $args, ConsoleIo $io)
+    {
+        /** @var \Cake\Queue\Model\Table\FailedJobsTable $failedJobsTable */
+        $failedJobsTable = $this->getTableLocator()->get('Cake/Queue.FailedJobs');
+
+        $jobsToRequeue = $failedJobsTable->find();
+
+        if ($args->hasArgument('ids')) {
+            $idsArg = $args->getArgument('ids');
+
+            if ($idsArg !== null) {
+                $ids = explode(',', $idsArg);
+
+                $jobsToRequeue->whereInList('id', $ids);
+            }
+        }
+
+        if ($args->hasOption('class')) {
+            $jobsToRequeue->where(['class' => $args->getOption('class')]);
+        }
+
+        if ($args->hasOption('queue')) {
+            $jobsToRequeue->where(['queue' => $args->getOption('queue')]);
+        }
+
+        if ($args->hasOption('config')) {
+            $jobsToRequeue->where(['config' => $args->getOption('config')]);
+        }
+
+        $requeueingCount = $jobsToRequeue->count();
+
+        if (!$requeueingCount) {
+            $io->out('0 jobs found.');
+
+            return;
+        }
+
+        if (!$args->getOption('force')) {
+            $confirmed = $io->askChoice("Requeue {$requeueingCount} jobs?", ['y', 'n'], 'n');
+
+            if ($confirmed !== 'y') {
+                return;
+            }
+        }
+
+        $io->out("Requeueing {$requeueingCount} jobs.");
+
+        $succeededCount = 0;
+        $failedCount = 0;
+
+        foreach ($jobsToRequeue as $failedJob) {
+            $io->verbose("Requeueing FailedJob with ID {$failedJob->id}.");
+            try {
+                QueueManager::push(
+                    [$failedJob->class, $failedJob->method],
+                    $failedJob->decoded_data,
+                    [
+                        'config' => $failedJob->config,
+                        'priority' => $failedJob->priority,
+                        'queue' => $failedJob->queue,
+                    ]
+                );
+
+                $failedJobsTable->deleteOrFail($failedJob);
+
+                $succeededCount++;
+            } catch (Exception $e) {
+                $io->err("Exception occurred while requeueing FailedJob with ID {$failedJob->id}");
+                $io->err((string)$e);
+
+                $failedCount++;
+            }
+        }
+
+        if ($failedCount) {
+            $io->err("Failed to requeue {$failedCount} jobs.");
+        }
+
+        if ($succeededCount) {
+            $io->success("{$succeededCount} jobs requeued.");
+        }
+    }
+}

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -24,6 +24,7 @@ use Cake\Core\Configure;
 use Cake\Log\Log;
 use Cake\Queue\Consumption\LimitAttemptsExtension;
 use Cake\Queue\Consumption\LimitConsumedMessagesExtension;
+use Cake\Queue\Listener\FailedJobsListener;
 use Cake\Queue\Queue\Processor;
 use Cake\Queue\QueueManager;
 use DateTime;
@@ -109,9 +110,13 @@ class WorkerCommand extends Command
      */
     protected function getQueueExtension(Arguments $args, LoggerInterface $logger): ExtensionInterface
     {
+        $limitAttempsExtension = new LimitAttemptsExtension((int)$args->getOption('max-attempts') ?: null);
+
+        $limitAttempsExtension->getEventManager()->on(new FailedJobsListener());
+
         $extensions = [
             new LoggerExtension($logger),
-            new LimitAttemptsExtension((int)$args->getOption('max-attempts') ?: null),
+            $limitAttempsExtension,
         ];
 
         if (!is_null($args->getOption('max-jobs'))) {

--- a/src/Job/Message.php
+++ b/src/Job/Message.php
@@ -106,7 +106,7 @@ class Message implements JsonSerializable
      *
      * @return array
      */
-    protected function getTarget(): array
+    public function getTarget(): array
     {
         $target = $this->parsedBody['class'] ?? null;
 

--- a/src/Listener/FailedJobsListener.php
+++ b/src/Listener/FailedJobsListener.php
@@ -1,0 +1,101 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         0.1.0
+ * @license       https://opensource.org/licenses/MIT MIT License
+ */
+namespace Cake\Queue\Listener;
+
+use Cake\Event\EventInterface;
+use Cake\Event\EventListenerInterface;
+use Cake\ORM\Exception\PersistenceFailedException;
+use Cake\ORM\Locator\LocatorAwareTrait;
+use Cake\Queue\QueueManager;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+class FailedJobsListener implements EventListenerInterface
+{
+    use LocatorAwareTrait;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function implementedEvents(): array
+    {
+        return [
+            'Consumption.LimitAttemptsExtension.failed' => 'storeFailedJob',
+        ];
+    }
+
+    /**
+     * @param \Cake\Event\EventInterface $event EventInterface
+     * @return void
+     */
+    public function storeFailedJob(EventInterface $event): void
+    {
+        /** @var \Cake\Queue\Job\Message $jobMessage */
+        $jobMessage = $event->getSubject();
+
+        [$class, $method] = $jobMessage->getTarget();
+
+        $originalMessage = $jobMessage->getOriginalMessage();
+
+        $originalMessageBody = json_decode($originalMessage->getBody(), true);
+
+        ['data' => $data, 'requeueOptions' => $requeueOptions] = $originalMessageBody;
+
+        $config = QueueManager::getConfig($requeueOptions['config']);
+
+        if (!($config['storeFailedJobs'] ?? false)) {
+            return;
+        }
+
+        /** @var \Cake\Queue\Model\Table\FailedJobsTable $failedJobsTable */
+        $failedJobsTable = $this->getTableLocator()->get('Cake/Queue.FailedJobs');
+
+        $failedJob = $failedJobsTable->newEntity([
+            'class' => $class,
+            'method' => $method,
+            'data' => json_encode($data),
+            'config' => $requeueOptions['config'],
+            'priority' => $requeueOptions['priority'],
+            'queue' => $requeueOptions['queue'],
+            'exception' => $event->getData('exception'),
+        ]);
+
+        try {
+            $failedJobsTable->saveOrFail($failedJob);
+        } catch (PersistenceFailedException $e) {
+            $logger = $event->getData('logger');
+
+            if (!$logger) {
+                throw new RuntimeException(
+                    sprintf('`logger` was not defined on %s event.', $event->getName()),
+                    0,
+                    $e
+                );
+            }
+
+            if (!($logger instanceof LoggerInterface)) {
+                throw new RuntimeException(
+                    sprintf('`logger` is not an instance of `LoggerInterface` on %s event.', $event->getName()),
+                    0,
+                    $e
+                );
+            }
+
+            $logger->error((string)$e);
+        }
+    }
+}

--- a/src/Listener/FailedJobsListener.php
+++ b/src/Listener/FailedJobsListener.php
@@ -76,6 +76,7 @@ class FailedJobsListener implements EventListenerInterface
 
         try {
             $failedJobsTable->saveOrFail($failedJob);
+        /** @phpstan-ignore-next-line */
         } catch (PersistenceFailedException $e) {
             $logger = $event->getData('logger');
 

--- a/src/Model/Entity/FailedJob.php
+++ b/src/Model/Entity/FailedJob.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Queue\Model\Entity;
+
+use Cake\ORM\Entity;
+
+/**
+ * FailedJob Entity
+ *
+ * @property int $id
+ * @property string $class
+ * @property string $method
+ * @property string $data
+ * @property string|null $config
+ * @property string|null $priority
+ * @property string|null $queue
+ * @property string|null $exception
+ * @property \Cake\I18n\FrozenTime|null $created
+ */
+class FailedJob extends Entity
+{
+    /**
+     * Map of fields in this entity that can be safely assigned, each
+     * field name points to a boolean indicating its status. An empty array
+     * means no fields are accessible
+     *
+     * The special field '\*' can also be mapped, meaning that any other field
+     * not defined in the map will take its value. For example, `'*' => true`
+     * means that any field not defined in the map will be accessible by default
+     *
+     * @var array<string, bool>
+     */
+    protected $_accessible = [
+        'class' => true,
+        'method' => true,
+        'data' => true,
+        'config' => true,
+        'priority' => true,
+        'queue' => true,
+        'exception' => true,
+        'created' => true,
+    ];
+
+    /**
+     * @return array
+     */
+    protected function _getDecodedData(): array
+    {
+        return json_decode($this->data, true);
+    }
+}

--- a/src/Model/Table/FailedJobsTable.php
+++ b/src/Model/Table/FailedJobsTable.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Queue\Model\Table;
+
+use Cake\ORM\Table;
+use Cake\Validation\Validator;
+
+/**
+ * FailedJobs Model
+ *
+ * @method \Cake\Queue\Model\Entity\FailedJob newEmptyEntity()
+ * @method \Cake\Queue\Model\Entity\FailedJob newEntity(array $data, array $options = [])
+ * @method \Cake\Queue\Model\Entity\FailedJob[] newEntities(array $data, array $options = [])
+ * @method \Cake\Queue\Model\Entity\FailedJob get($primaryKey, $options = [])
+ * @method \Cake\Queue\Model\Entity\FailedJob findOrCreate($search, ?callable $callback = null, $options = [])
+ * @method \Cake\Queue\Model\Entity\FailedJob patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
+ * @method \Cake\Queue\Model\Entity\FailedJob[] patchEntities(iterable $entities, array $data, array $options = [])
+ * @method \Cake\Queue\Model\Entity\FailedJob|false save(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \Cake\Queue\Model\Entity\FailedJob saveOrFail(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \Cake\Queue\Model\Entity\FailedJob[]|\Cake\Datasource\ResultSetInterface|false saveMany(iterable $entities, $options = [])
+ * @method \Cake\Queue\Model\Entity\FailedJob[]|\Cake\Datasource\ResultSetInterface saveManyOrFail(iterable $entities, $options = [])
+ * @method \Cake\Queue\Model\Entity\FailedJob[]|\Cake\Datasource\ResultSetInterface|false deleteMany(iterable $entities, $options = [])
+ * @method \Cake\Queue\Model\Entity\FailedJob[]|\Cake\Datasource\ResultSetInterface deleteManyOrFail(iterable $entities, $options = [])
+ * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ */
+class FailedJobsTable extends Table
+{
+    /**
+     * Initialize method
+     *
+     * @param array $config The configuration for the Table.
+     * @return void
+     */
+    public function initialize(array $config): void
+    {
+        parent::initialize($config);
+
+        $this->setTable('queue_failed_jobs');
+        $this->setDisplayField('id');
+        $this->setPrimaryKey('id');
+
+        $this->addBehavior('Timestamp');
+    }
+
+    /**
+     * Default validation rules.
+     *
+     * @param \Cake\Validation\Validator $validator Validator instance.
+     * @return \Cake\Validation\Validator
+     */
+    public function validationDefault(Validator $validator): Validator
+    {
+        $validator
+            ->integer('id')
+            ->allowEmptyString('id', null, 'create');
+
+        $validator
+            ->scalar('class')
+            ->maxLength('class', 255)
+            ->requirePresence('class', 'create')
+            ->notEmptyString('class');
+
+        $validator
+            ->scalar('method')
+            ->maxLength('method', 255)
+            ->requirePresence('method', 'create')
+            ->notEmptyString('method');
+
+        $validator
+            ->scalar('data')
+            ->requirePresence('data', 'create')
+            ->notEmptyString('data');
+
+        $validator
+            ->scalar('config')
+            ->maxLength('config', 255)
+            ->notEmptyString('config');
+
+        $validator
+            ->scalar('priority')
+            ->maxLength('priority', 255)
+            ->allowEmptyString('priority');
+
+        $validator
+            ->scalar('queue')
+            ->maxLength('queue', 255)
+            ->notEmptyString('queue');
+
+        $validator
+            ->scalar('exception')
+            ->allowEmptyString('exception');
+
+        return $validator;
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -21,6 +21,8 @@ use Cake\Core\BasePlugin;
 use Cake\Core\Configure;
 use Cake\Core\PluginApplicationInterface;
 use Cake\Queue\Command\JobCommand;
+use Cake\Queue\Command\PurgeFailedCommand;
+use Cake\Queue\Command\RequeueCommand;
 use Cake\Queue\Command\WorkerCommand;
 
 /**
@@ -71,6 +73,8 @@ class Plugin extends BasePlugin
 
         return $commands
             ->add('queue worker', WorkerCommand::class)
-            ->add('worker', WorkerCommand::class);
+            ->add('worker', WorkerCommand::class)
+            ->add('queue requeue', RequeueCommand::class)
+            ->add('queue purge_failed', PurgeFailedCommand::class);
     }
 }

--- a/src/Queue/Processor.php
+++ b/src/Queue/Processor.php
@@ -18,6 +18,7 @@ namespace Cake\Queue\Queue;
 
 use Cake\Event\EventDispatcherTrait;
 use Cake\Queue\Job\Message;
+use Enqueue\Consumption\Result;
 use Error;
 use Exception;
 use Interop\Queue\Context;
@@ -78,7 +79,7 @@ class Processor implements InteropProcessor
                 'exception' => $e,
             ]);
 
-            return InteropProcessor::REQUEUE;
+            return Result::requeue(sprintf('Exception occurred while processing message: %s', (string)$e));
         }
 
         if ($response === InteropProcessor::ACK) {

--- a/src/QueueManager.php
+++ b/src/QueueManager.php
@@ -216,6 +216,11 @@ class QueueManager
             'class' => [$class, $method],
             'args' => [$data],
             'data' => $data,
+            'requeueOptions' => [
+                'config' => $name,
+                'priority' => $options['priority'] ?? null,
+                'queue' => $queue,
+            ],
         ]);
 
         if (isset($options['delay'])) {

--- a/tests/Fixture/FailedJobsFixture.php
+++ b/tests/Fixture/FailedJobsFixture.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Queue\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+use TestApp\Job\LogToDebugJob;
+use TestApp\Job\MaxAttemptsIsThreeJob;
+
+/**
+ * FailedJobsFixture
+ */
+class FailedJobsFixture extends TestFixture
+{
+    public $table = 'queue_failed_jobs';
+
+    /**
+     * Fields
+     *
+     * @var array
+     */
+    // phpcs:disable
+    public $fields = [
+        'id' => ['type' => 'integer', 'length' => null, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'autoIncrement' => true, 'precision' => null],
+        'class' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+        'method' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+        'data' => ['type' => 'text', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+        'config' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
+        'priority' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
+        'queue' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
+        'exception' => ['type' => 'text', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
+        'created' => ['type' => 'datetime', 'length' => null, 'precision' => null, 'null' => true, 'default' => null, 'comment' => ''],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
+        ],
+        '_options' => [
+            'engine' => 'InnoDB',
+        ],
+    ];
+    // phpcs:enable
+    /**
+     * Init method
+     *
+     * @return void
+     */
+    public function init(): void
+    {
+        $this->records = [
+            [
+                'id' => 1,
+                'class' => LogToDebugJob::class,
+                'method' => 'execute',
+                'data' => '{"sample_data_1": "sample value", "sample_data_2": 1}',
+                'config' => 'default',
+                'priority' => null,
+                'queue' => 'default',
+                'exception' => 'Lorem ipsum dolor sit amet, aliquet feugiat. Convallis morbi fringilla gravida, phasellus feugiat dapibus velit nunc, pulvinar eget sollicitudin venenatis cum nullam, vivamus ut a sed, mollitia lectus. Nulla vestibulum massa neque ut et, id hendrerit sit, feugiat in taciti enim proin nibh, tempor dignissim, rhoncus duis vestibulum nunc mattis convallis.',
+                'created' => '2022-10-11 18:42:29',
+            ],
+            [
+                'id' => 2,
+                'class' => MaxAttemptsIsThreeJob::class,
+                'method' => 'execute',
+                'data' => '{"sample_data_1": "sample value", "sample_data_2": 1}',
+                'config' => 'default',
+                'priority' => null,
+                'queue' => 'default',
+                'exception' => 'Lorem ipsum dolor sit amet, aliquet feugiat. Convallis morbi fringilla gravida, phasellus feugiat dapibus velit nunc, pulvinar eget sollicitudin venenatis cum nullam, vivamus ut a sed, mollitia lectus. Nulla vestibulum massa neque ut et, id hendrerit sit, feugiat in taciti enim proin nibh, tempor dignissim, rhoncus duis vestibulum nunc mattis convallis.',
+                'created' => '2022-10-11 18:42:29',
+            ],
+            [
+                'id' => 3,
+                'class' => LogToDebugJob::class,
+                'method' => 'execute',
+                'data' => '{"sample_data_1": "sample value", "sample_data_2": 1}',
+                'config' => 'alternate_config',
+                'priority' => null,
+                'queue' => 'alternate_queue',
+                'exception' => 'Lorem ipsum dolor sit amet, aliquet feugiat. Convallis morbi fringilla gravida, phasellus feugiat dapibus velit nunc, pulvinar eget sollicitudin venenatis cum nullam, vivamus ut a sed, mollitia lectus. Nulla vestibulum massa neque ut et, id hendrerit sit, feugiat in taciti enim proin nibh, tempor dignissim, rhoncus duis vestibulum nunc mattis convallis.',
+                'created' => '2022-10-11 18:42:29',
+            ],
+        ];
+        parent::init();
+    }
+}

--- a/tests/TestCase/Command/PurgeFailedCommandTest.php
+++ b/tests/TestCase/Command/PurgeFailedCommandTest.php
@@ -1,0 +1,120 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         0.1.0
+ * @license       https://opensource.org/licenses/MIT MIT License
+ */
+namespace Cake\Queue\Test\TestCase\Command;
+
+use Cake\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+use TestApp\Job\LogToDebugJob;
+
+/**
+ * Class PurgeFailedCommandTest
+ *
+ * @package Queue\Test\TestCase\Command
+ */
+class PurgeFailedCommandTest extends TestCase
+{
+    use ConsoleIntegrationTestTrait;
+
+    protected $fixtures = [
+        'plugin.Cake/Queue.FailedJobs',
+    ];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->useCommandRunner();
+    }
+
+    public function testFailedJobsAreDeleted()
+    {
+        $this->exec('queue purge_failed', ['y']);
+
+        $this->assertOutputContains('Deleting 3 jobs.');
+        $this->assertOutputContains('3 jobs deleted.');
+
+        $results = $this->getTableLocator()->get('Cake/Queue.FailedJobs')->find()->all();
+
+        $this->assertCount(0, $results);
+    }
+
+    public function testFailedJobsAreNotDeletedIfNotConfirmed()
+    {
+        $this->exec('queue purge_failed', ['n']);
+
+        $this->assertOutputNotContains('Deleting');
+        $this->assertOutputNotContains('deleted.');
+
+        $results = $this->getTableLocator()->get('Cake/Queue.FailedJobs')->find()->all();
+
+        $this->assertCount(3, $results);
+    }
+
+    public function testFailedJobsAreDeletedById()
+    {
+        $this->exec('queue purge_failed 1,2 -f');
+
+        $this->assertOutputContains('Deleting 2 jobs.');
+        $this->assertOutputContains('2 jobs deleted.');
+
+        $results = $this->getTableLocator()->get('Cake/Queue.FailedJobs')->find()->toArray();
+
+        $this->assertCount(1, $results);
+        $this->assertSame(3, $results[0]->id);
+    }
+
+    public function testFailedJobsAreDeletedByClass()
+    {
+        $class = LogToDebugJob::class;
+        $this->exec("queue purge_failed --class {$class} -f");
+
+        $this->assertOutputContains('Deleting 2 jobs.');
+        $this->assertOutputContains('2 jobs deleted.');
+
+        $results = $this->getTableLocator()->get('Cake/Queue.FailedJobs')->find()->toArray();
+
+        $this->assertCount(1, $results);
+        $this->assertSame(2, $results[0]->id);
+    }
+
+    public function testFailedJobsAreDeletedByQueue()
+    {
+        $this->exec('queue purge_failed --queue alternate_queue -f');
+
+        $this->assertOutputContains('Deleting 1 jobs.');
+        $this->assertOutputContains('1 jobs deleted.');
+
+        $results = $this->getTableLocator()->get('Cake/Queue.FailedJobs')->find()->toArray();
+
+        $this->assertCount(2, $results);
+        $this->assertSame(1, $results[0]->id);
+        $this->assertSame(2, $results[1]->id);
+    }
+
+    public function testFailedJobsAreDeletedByConfig()
+    {
+        $this->exec('queue purge_failed --config alternate_config -f');
+
+        $this->assertOutputContains('Deleting 1 jobs.');
+        $this->assertOutputContains('1 jobs deleted.');
+
+        $results = $this->getTableLocator()->get('Cake/Queue.FailedJobs')->find()->toArray();
+
+        $this->assertCount(2, $results);
+        $this->assertSame(1, $results[0]->id);
+        $this->assertSame(2, $results[1]->id);
+    }
+}

--- a/tests/TestCase/Command/RequeueCommandTest.php
+++ b/tests/TestCase/Command/RequeueCommandTest.php
@@ -1,0 +1,204 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         0.1.0
+ * @license       https://opensource.org/licenses/MIT MIT License
+ */
+namespace Cake\Queue\Test\TestCase\Command;
+
+use Cake\Core\Configure;
+use Cake\Log\Log;
+use Cake\Queue\QueueManager;
+use Cake\Queue\Test\TestCase\DebugLogTrait;
+use Cake\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+use TestApp\Job\LogToDebugJob;
+
+/**
+ * Class RequeueCommandTest
+ *
+ * @package Queue\Test\TestCase\Command
+ */
+class RequeueCommandTest extends TestCase
+{
+    use ConsoleIntegrationTestTrait;
+    use DebugLogTrait;
+
+    protected $fixtures = [
+        'plugin.Cake/Queue.FailedJobs',
+    ];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->useCommandRunner();
+
+        Log::setConfig('debug', [
+            'className' => 'Array',
+            'levels' => ['notice', 'info', 'debug'],
+        ]);
+
+        $config = [
+            'queue' => 'default',
+            'url' => 'file:///' . TMP . DS . uniqid('queue'),
+            'receiveTimeout' => 100,
+        ];
+        Configure::write('Queue', ['default' => $config]);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        Log::reset();
+
+        QueueManager::drop('default');
+    }
+
+    public function testJobsAreRequeued()
+    {
+        $this->exec('queue worker --max-jobs=3 --logger=debug --verbose');
+        QueueManager::drop('default');
+
+        $this->assertDebugLogContainsExactly('Debug job was run', 0);
+        $this->assertDebugLogContainsExactly('MaxAttemptsIsThreeJob is requeueing', 0);
+
+        $this->cleanupConsoleTrait();
+        $this->useCommandRunner();
+        $this->exec('queue requeue --queue default', ['y']);
+
+        $this->assertOutputContains('Requeueing 2 jobs.');
+        $this->assertOutputContains('2 jobs requeued.');
+
+        $this->exec('queue worker --max-jobs=3 --logger=debug --verbose');
+
+        $this->assertDebugLogContainsExactly('Debug job was run', 1);
+        $this->assertDebugLogContains('MaxAttemptsIsThreeJob is requeueing');
+    }
+
+    public function testJobsAreNotRequeuedIfNotConfirmed()
+    {
+        $this->exec('queue worker --max-jobs=3 --logger=debug --verbose');
+        QueueManager::drop('default');
+
+        $this->assertDebugLogContainsExactly('Debug job was run', 0);
+        $this->assertDebugLogContainsExactly('MaxAttemptsIsThreeJob is requeueing', 0);
+
+        $this->cleanupConsoleTrait();
+        $this->useCommandRunner();
+        $this->exec('queue requeue --queue default', ['n']);
+
+        $this->assertOutputNotContains('Requeueing');
+        $this->assertOutputNotContains('requeued.');
+
+        $this->exec('queue worker --max-jobs=3 --logger=debug --verbose');
+
+        $this->assertDebugLogContainsExactly('Debug job was run', 0);
+        $this->assertDebugLogContainsExactly('MaxAttemptsIsThreeJob is requeueing', 0);
+    }
+
+    public function testJobsAreRequeuedById()
+    {
+        $this->exec('queue worker --max-jobs=3 --logger=debug --verbose');
+        QueueManager::drop('default');
+
+        $this->assertDebugLogContainsExactly('Debug job was run', 0);
+        $this->assertDebugLogContainsExactly('MaxAttemptsIsThreeJob was run', 0);
+
+        $this->cleanupConsoleTrait();
+        $this->useCommandRunner();
+        $this->exec('queue requeue 1,2 -f');
+
+        $this->assertOutputContains('Requeueing 2 jobs.');
+        $this->assertOutputContains('2 jobs requeued.');
+
+        $this->exec('queue worker --max-jobs=3 --logger=debug --verbose');
+
+        $this->assertDebugLogContainsExactly('Debug job was run', 1);
+        $this->assertDebugLogContains('MaxAttemptsIsThreeJob is requeueing');
+    }
+
+    public function testJobsAreRequeuedByClass()
+    {
+        $this->exec('queue worker --max-jobs=3 --logger=debug --verbose');
+        QueueManager::drop('default');
+
+        $this->assertDebugLogContainsExactly('Debug job was run', 0);
+
+        $this->cleanupConsoleTrait();
+        $this->useCommandRunner();
+        $class = LogToDebugJob::class;
+        $this->exec("queue requeue --class {$class} --queue default -f");
+
+        $this->assertOutputContains('Requeueing 1 jobs.');
+        $this->assertOutputContains('1 jobs requeued.');
+
+        $this->exec('queue worker --max-jobs=3 --logger=debug --verbose');
+
+        $this->assertDebugLogContainsExactly('Debug job was run', 1);
+    }
+
+    public function testJobsAreRequeuedByQueue()
+    {
+        $config = [
+            'queue' => 'alternate_queue',
+            'url' => 'file:///' . TMP . DS . 'queue' . uniqid('queue'),
+            'receiveTimeout' => 100,
+        ];
+        Configure::write('Queue', ['alternate_config' => $config]);
+
+        $this->exec('queue worker --max-jobs=3 --logger=debug --config alternate_config --verbose');
+        QueueManager::drop('alternate_config');
+
+        $this->assertDebugLogContainsExactly('Debug job was run', 0);
+
+        $this->cleanupConsoleTrait();
+        $this->useCommandRunner();
+        $this->exec('queue requeue --queue alternate_queue -f');
+
+        $this->assertOutputContains('Requeueing 1 jobs.');
+        $this->assertOutputContains('1 jobs requeued.');
+
+        $this->exec('queue worker --max-jobs=3 --logger=debug --config alternate_config --verbose');
+        QueueManager::drop('alternate_config');
+
+        $this->assertDebugLogContains('Debug job was run');
+    }
+
+    public function testJobsAreRequeuedByConfig()
+    {
+        $config = [
+            'queue' => 'alternate_queue',
+            'url' => 'file:///' . TMP . DS . 'queue' . uniqid('queue'),
+            'receiveTimeout' => 100,
+        ];
+        Configure::write('Queue', ['alternate_config' => $config]);
+
+        $this->exec('queue worker --max-jobs=3 --logger=debug --config alternate_config --verbose');
+        QueueManager::drop('alternate_config');
+
+        $this->assertDebugLogContainsExactly('Debug job was run', 0);
+
+        $this->cleanupConsoleTrait();
+        $this->useCommandRunner();
+        $this->exec('queue requeue --config alternate_config -f');
+
+        $this->assertOutputContains('Requeueing 1 jobs.');
+        $this->assertOutputContains('1 jobs requeued.');
+
+        $this->exec('queue worker --max-jobs=3 --logger=debug --config alternate_config --verbose');
+        QueueManager::drop('alternate_config');
+
+        $this->assertDebugLogContains('Debug job was run');
+    }
+}

--- a/tests/TestCase/DebugLogTrait.php
+++ b/tests/TestCase/DebugLogTrait.php
@@ -7,7 +7,7 @@ use Cake\Log\Log;
 
 trait DebugLogTrait
 {
-    protected function assertDebugLogContains($expected, $times = null): void
+    protected function assertDebugLogContains($expected): void
     {
         $found = $this->debugLogCount($expected);
 

--- a/tests/TestCase/Listener/FailedJobsListenerTest.php
+++ b/tests/TestCase/Listener/FailedJobsListenerTest.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         0.1.0
+ * @license       https://opensource.org/licenses/MIT MIT License
+ */
+namespace Cake\Queue\Test\TestCase\Mailer;
+
+use Cake\Event\Event;
+use Cake\Event\EventManager;
+use Cake\Queue\Job\Message;
+use Cake\Queue\Listener\FailedJobsListener;
+use Cake\Queue\QueueManager;
+use Cake\TestSuite\TestCase;
+use Enqueue\Null\NullConnectionFactory;
+use Enqueue\Null\NullMessage;
+use TestApp\Job\LogToDebugJob;
+
+class FailedJobsListenerTest extends TestCase
+{
+    protected $fixtures = [
+        'plugin.Cake/Queue.FailedJobs',
+    ];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        QueueManager::setConfig('example_config', [
+            'url' => 'null:',
+            'storeFailedJobs' => true,
+        ]);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        QueueManager::drop('example_config');
+    }
+
+    public function testFailedJobIsAddedWhenEventIsFired()
+    {
+        $parsedBody = [
+            'class' => [LogToDebugJob::class, 'execute'],
+            'data' => ['example_key' => 'example_value'],
+            'requeueOptions' => [
+                'config' => 'example_config',
+                'priority' => 'example_priority',
+                'queue' => 'example_queue',
+            ],
+        ];
+        $messageBody = json_encode($parsedBody);
+        $connectionFactory = new NullConnectionFactory();
+
+        $context = $connectionFactory->createContext();
+        $originalMessage = new NullMessage($messageBody);
+        $message = new Message($originalMessage, $context);
+
+        $event = new Event(
+            'Consumption.LimitAttemptsExtension.failed',
+            $message,
+            ['exception' => 'some message']
+        );
+
+        /** @var \Cake\Queue\Model\Table\FailedJobsTable $failedJobsTable */
+        $failedJobsTable = $this->getTableLocator()->get('Cake/Queue.FailedJobs');
+        $failedJobsTable->deleteAll(['1=1']);
+
+        EventManager::instance()->on(new FailedJobsListener());
+        EventManager::instance()->dispatch($event);
+
+        $this->assertSame(1, $failedJobsTable->find()->count());
+
+        $failedJob = $failedJobsTable->find()->first();
+
+        $this->assertSame(LogToDebugJob::class, $failedJob->class);
+        $this->assertSame('execute', $failedJob->method);
+        $this->assertSame(json_encode(['example_key' => 'example_value']), $failedJob->data);
+        $this->assertSame('example_config', $failedJob->config);
+        $this->assertSame('example_priority', $failedJob->priority);
+        $this->assertSame('example_queue', $failedJob->queue);
+        $this->assertStringContainsString('some message', $failedJob->exception);
+    }
+}

--- a/tests/TestCase/Queue/ProcessorTest.php
+++ b/tests/TestCase/Queue/ProcessorTest.php
@@ -153,7 +153,7 @@ class ProcessorTest extends TestCase
         $processor->getEventManager()->setEventList($events);
 
         $result = $processor->process($queueMessage, $context);
-        $this->assertSame(InteropProcessor::REQUEUE, $result);
+        $this->assertEquals(InteropProcessor::REQUEUE, $result);
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
  * @license       http://www.opensource.org/licenses/mit-license.php MIT License
  */
 
+use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Routing\Router;
 
@@ -44,6 +45,25 @@ define('CACHE', sys_get_temp_dir() . DS . 'cache' . DS);
 if (!defined('CONFIG')) {
     define('CONFIG', ROOT . DS . 'config' . DS);
 }
+
+// phpcs:disable
+@mkdir(CACHE);
+@mkdir(CACHE . 'views');
+@mkdir(CACHE . 'models');
+// phpcs:enable
+
+Cache::setConfig([
+    '_cake_core_' => [
+        'engine' => 'File',
+        'prefix' => 'cake_core_',
+        'serialize' => true,
+    ],
+    '_cake_model_' => [
+        'engine' => 'File',
+        'prefix' => 'cake_model_',
+        'serialize' => true,
+    ],
+]);
 
 Configure::write('debug', true);
 Configure::write('App', [

--- a/tests/test_app/src/Job/MaxAttemptsIsThreeJob.php
+++ b/tests/test_app/src/Job/MaxAttemptsIsThreeJob.php
@@ -8,6 +8,7 @@ use Cake\Queue\Consumption\LimitAttemptsExtension;
 use Cake\Queue\Job\JobInterface;
 use Cake\Queue\Job\Message;
 use Interop\Queue\Processor;
+use RuntimeException;
 
 class MaxAttemptsIsThreeJob implements JobInterface
 {
@@ -23,7 +24,7 @@ class MaxAttemptsIsThreeJob implements JobInterface
         if (!$succeedAt || $succeedAt > $attemptNumber) {
             Log::debug('MaxAttemptsIsThreeJob is requeueing');
 
-            return Processor::REQUEUE;
+            throw new RuntimeException('example MaxAttemptsIsThreeJob exception message');
         }
 
         Log::debug('MaxAttemptsIsThreeJob was run');


### PR DESCRIPTION
This adds support for storing and manually requeuing failed jobs (defined as jobs that have exceeded `maxAttempts`). This would lay some groundwork for https://github.com/cakephp/queue/issues/11.

This is a somewhat significant set of changes so I'm very open to any feedback.

Many thanks to @amayer5125 for his suggestions and review.