### PR TITLE
Implement QueueTransport to enqueue emails automatically Fixes #64

### DIFF
--- a/src/Job/SendMailJob.php
+++ b/src/Job/SendMailJob.php
@@ -37,14 +37,19 @@ class SendMailJob implements JobInterface
             /** @var \Cake\Mailer\AbstractTransport $transport */
             $transport = $this->getTransport($transportClassName, $config);
 
-            $emailMessage = unserialize($message->getArgument('emailMessage'));
+            $emailMessage = new \Cake\Mailer\Message();
+            $data = json_decode($message->getArgument('emailMessage'), true);
+            if (!is_array($data)) {
+                throw new \InvalidArgumentException('Email Message cannot be decoded.');
+            }
+            $emailMessage->createFromArray($data);
             $result = $transport->send($emailMessage);
         } catch (\Exception $e) {
             Log::error(sprintf('An error has occurred processing message: %s', $e->getMessage()));
-        } finally {
-            if (!$result) {
-                return Processor::REJECT;
-            }
+        }
+
+        if (!$result) {
+            return Processor::REJECT;
         }
 
         return Processor::ACK;

--- a/src/Job/SendMailJob.php
+++ b/src/Job/SendMailJob.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         0.1.9
+ * @license       https://opensource.org/licenses/MIT MIT License
+ */
+namespace Cake\Queue\Job;
+
+use Cake\Queue\Queue\Processor;
+
+/**
+ * SendMailJob class to be used by QueueTransport to enqueue emails
+ */
+class SendMailJob implements JobInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function execute(Message $message): ?string
+    {
+        $transportClassName = $message->getArgument('transport');
+        $config = $message->getArgument('config');
+        $emailMessage = unserialize($message->getArgument('emailMessage'));
+        try {
+            /** @var \Cake\Mailer\AbstractTransport $transport */
+            $transport = new $transportClassName($config);
+            $result = $transport->send($emailMessage);
+        } catch (\Exception $e) {
+            return Processor::REJECT;
+        }
+
+        return Processor::ACK;
+    }
+}

--- a/src/Mailer/Transport/QueueTransport.php
+++ b/src/Mailer/Transport/QueueTransport.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         0.1.9
+ * @license       https://opensource.org/licenses/MIT MIT License
+ */
+namespace Cake\Queue\Mailer\Transport;
+
+use Cake\Mailer\Message;
+use Cake\Mailer\Transport\MailTransport;
+use Cake\Queue\Job\SendMailJob;
+use Cake\Queue\QueueManager;
+
+class QueueTransport extends \Cake\Mailer\AbstractTransport
+{
+    /**
+     * Default config for this class
+     *
+     * @var array<string, mixed>
+     */
+    protected $_defaultConfig = [
+        'options' => [],
+        'transport' => MailTransport::class,
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    public function send(Message $message): array
+    {
+        QueueManager::push(
+            [SendMailJob::class, 'execute'],
+            [
+                'transport' => $this->getConfig('transport'),
+                'config' => $this->getConfig(),
+                'emailMessage' => serialize($message),
+            ],
+            $this->getConfig('options')
+        );
+
+        $headers = $message->getHeadersString(
+            [
+                'from',
+                'to',
+                'subject',
+                'sender',
+                'replyTo',
+                'readReceipt',
+                'returnPath',
+                'cc',
+                'bcc',
+            ],
+        );
+
+        return ['headers' => $headers, 'message' => 'Message has been enqueued'];
+    }
+}

--- a/src/Mailer/Transport/QueueTransport.php
+++ b/src/Mailer/Transport/QueueTransport.php
@@ -86,7 +86,7 @@ class QueueTransport extends \Cake\Mailer\AbstractTransport
         return [
             'transport' => $this->getConfig('transport'),
             'config' => $this->getConfig(),
-            'emailMessage' => serialize($message),
+            'emailMessage' => json_encode($message),
         ];
     }
 }

--- a/tests/TestCase/Job/SendMailJobTest.php
+++ b/tests/TestCase/Job/SendMailJobTest.php
@@ -1,0 +1,112 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         0.1.9
+ * @license       https://opensource.org/licenses/MIT MIT License
+ */
+namespace Cake\Queue\Test\TestCase\Job;
+
+use Cake\Mailer\Transport\DebugTransport;
+use Cake\Queue\Job\Message;
+use Cake\Queue\Job\SendMailJob;
+use Cake\Queue\Queue\Processor;
+use Cake\TestSuite\TestCase;
+use Enqueue\Null\NullConnectionFactory;
+use Enqueue\Null\NullMessage;
+
+class SendMailJobTest extends TestCase
+{
+    /**
+     * @var \Cake\Queue\Job\SendMailJob
+     */
+    protected $job;
+
+    /**
+     * @var \Cake\Mailer\Message
+     */
+    protected $message;
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->job = new SendMailJob();
+        $this->message = (new \Cake\Mailer\Message())
+            ->setFrom('from@example.com')
+            ->setTo('to@example.com')
+            ->setSubject('Sample Subject');
+    }
+
+    /**
+     * Test execute method
+     *
+     * @return void
+     */
+    public function testExecute()
+    {
+        $message = $this->createMessage(DebugTransport::class, [], $this->message);
+        $actual = $this->job->execute($message);
+        $this->assertSame(Processor::ACK, $actual);
+    }
+
+    /**
+     * Test execute method with invalid transport
+     *
+     * @return void
+     */
+    public function testExecuteInvalidTransport()
+    {
+        $message = $this->createMessage('WrongTransport', [], $this->message);
+        $actual = $this->job->execute($message);
+        $this->assertSame(Processor::REJECT, $actual);
+    }
+
+    /**
+     * Test execute method with unserializable message
+     *
+     * @return void
+     */
+    public function testExecuteUnserializableMessage()
+    {
+        $message = $this->createMessage(DebugTransport::class, [], 'unserializable');
+        $actual = $this->job->execute($message);
+        $this->assertSame(Processor::REJECT, $actual);
+    }
+
+    /**
+     * Create a simple message for testing.
+     *
+     * @return \Cake\Queue\Job\Message
+     */
+    protected function createMessage($transport, $config, $emailMessage): Message
+    {
+        $messageBody = [
+            'class' => ['Queue\\Job\\SendMailJob', 'execute'],
+            'data' => [
+                'transport' => $transport,
+                'config' => $config,
+                'emailMessage' => serialize($emailMessage),
+
+            ],
+        ];
+        $connectionFactory = new NullConnectionFactory();
+        $context = $connectionFactory->createContext();
+        $originalMessage = new NullMessage(json_encode($messageBody));
+        $message = new Message($originalMessage, $context);
+
+        return $message;
+    }
+}

--- a/tests/TestCase/Job/SendMailJobTest.php
+++ b/tests/TestCase/Job/SendMailJobTest.php
@@ -58,8 +58,23 @@ class SendMailJobTest extends TestCase
      */
     public function testExecute()
     {
+        $job = $this->getMockBuilder(SendMailJob::class)
+            ->onlyMethods(['getTransport'])
+            ->getMock();
         $message = $this->createMessage(DebugTransport::class, [], $this->message);
-        $actual = $this->job->execute($message);
+        $emailMessage = new \Cake\Mailer\Message();
+        $data = json_decode($message->getArgument('emailMessage'), true);
+        $emailMessage->createFromArray($data);
+        $transport = $this->getMockBuilder(DebugTransport::class)->getMock();
+        $transport->expects($this->once())
+            ->method('send')
+            ->with($emailMessage)
+            ->willReturn(['message' => 'test', 'headers' => []]);
+        $job->expects($this->once())
+            ->method('getTransport')
+            ->with(DebugTransport::class, [])
+            ->willReturn($transport);
+        $actual = $job->execute($message);
         $this->assertSame(Processor::ACK, $actual);
     }
 

--- a/tests/TestCase/Job/SendMailJobTest.php
+++ b/tests/TestCase/Job/SendMailJobTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 namespace Cake\Queue\Test\TestCase\Job;
 
+use Cake\Mailer\Mailer;
 use Cake\Mailer\Transport\DebugTransport;
 use Cake\Queue\Job\Message;
 use Cake\Queue\Job\SendMailJob;
@@ -63,6 +64,20 @@ class SendMailJobTest extends TestCase
     }
 
     /**
+     * Test execute with attachments method
+     *
+     * @return void
+     */
+    public function testExecuteWithAttachments()
+    {
+        $emailMessage = clone $this->message;
+        $emailMessage->addAttachments(['test.txt' => ROOT . 'files' . DS . 'test.txt']);
+        $message = $this->createMessage(DebugTransport::class, [], $emailMessage);
+        $actual = $this->job->execute($message);
+        $this->assertSame(Processor::ACK, $actual);
+    }
+
+    /**
      * Test execute method with invalid transport
      *
      * @return void
@@ -86,6 +101,13 @@ class SendMailJobTest extends TestCase
         $this->assertSame(Processor::REJECT, $actual);
     }
 
+    public function testExecuteNoAbstractTransport()
+    {
+        $message = $this->createMessage(Mailer::class, [], $this->message);
+        $actual = $this->job->execute($message);
+        $this->assertSame(Processor::REJECT, $actual);
+    }
+
     /**
      * Create a simple message for testing.
      *
@@ -98,7 +120,7 @@ class SendMailJobTest extends TestCase
             'data' => [
                 'transport' => $transport,
                 'config' => $config,
-                'emailMessage' => serialize($emailMessage),
+                'emailMessage' => json_encode($emailMessage),
 
             ],
         ];

--- a/tests/TestCase/Mailer/Transport/QueueTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/QueueTransportTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Queue\Test\TestCase\Job;
 
 use Cake\Queue\Mailer\Transport\QueueTransport;
+use Cake\Queue\QueueManager;
 use Cake\TestSuite\TestCase;
 
 class QueueTransportTest extends TestCase
@@ -28,26 +29,17 @@ class QueueTransportTest extends TestCase
      */
     public function testSend()
     {
+        QueueManager::setConfig('default', [
+            'queue' => 'default',
+            'url' => 'null:',
+        ]);
         $message = (new \Cake\Mailer\Message())
             ->setFrom('from@example.com')
             ->setTo('to@example.com')
             ->setSubject('Sample Subject');
 
-        $transport = $this
-            ->getMockBuilder(QueueTransport::class)->onlyMethods(['enqueueJob'])
-            ->getMock();
-        $expectedData = [
-            'transport' => 'Cake\Mailer\Transport\MailTransport',
-            'config' => [
-                'options' => [],
-                'transport' => 'Cake\Mailer\Transport\MailTransport',
-            ],
-            'emailMessage' => serialize($message),
-        ];
-        $expectedOptions = [];
-        $transport->expects($this->once())
-            ->method('enqueueJob')
-            ->with($expectedData, $expectedOptions);
+        $transport = new QueueTransport();
+
         $result = $transport->send($message);
 
         $headers = $message->getHeadersString(
@@ -66,5 +58,6 @@ class QueueTransportTest extends TestCase
 
         $expected = ['headers' => $headers, 'message' => 'Message has been enqueued'];
         $this->assertEquals($expected, $result);
+        QueueManager::drop('default');
     }
 }

--- a/tests/TestCase/Mailer/Transport/QueueTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/QueueTransportTest.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         0.1.9
+ * @license       https://opensource.org/licenses/MIT MIT License
+ */
+namespace Cake\Queue\Test\TestCase\Job;
+
+use Cake\Queue\Mailer\Transport\QueueTransport;
+use Cake\TestSuite\TestCase;
+
+class QueueTransportTest extends TestCase
+{
+    /**
+     * Test send
+     *
+     * @return void
+     */
+    public function testSend()
+    {
+        $message = (new \Cake\Mailer\Message())
+            ->setFrom('from@example.com')
+            ->setTo('to@example.com')
+            ->setSubject('Sample Subject');
+
+        $transport = $this
+            ->getMockBuilder(QueueTransport::class)->onlyMethods(['enqueueJob'])
+            ->getMock();
+        $expectedData = [
+            'transport' => 'Cake\Mailer\Transport\MailTransport',
+            'config' => [
+                'options' => [],
+                'transport' => 'Cake\Mailer\Transport\MailTransport',
+            ],
+            'emailMessage' => serialize($message),
+        ];
+        $expectedOptions = [];
+        $transport->expects($this->once())
+            ->method('enqueueJob')
+            ->with($expectedData, $expectedOptions);
+        $result = $transport->send($message);
+
+        $headers = $message->getHeadersString(
+            [
+                'from',
+                'to',
+                'subject',
+                'sender',
+                'replyTo',
+                'readReceipt',
+                'returnPath',
+                'cc',
+                'bcc',
+            ]
+        );
+
+        $expected = ['headers' => $headers, 'message' => 'Message has been enqueued'];
+        $this->assertEquals($expected, $result);
+    }
+}

--- a/tests/test_app/files/test.txt
+++ b/tests/test_app/files/test.txt
@@ -1,0 +1,1 @@
+TEST CONTENT


### PR DESCRIPTION
Fixes #64 

I have implemented `QueueTransport` to automatically enqueue emails, and `SendMailJob` to process those emails.

Config options are:

`options`: Options array to be passed to `push` method. It allows to keep emails on a different queue or with different params.
`transport`: Transport class name, to be initialized into `SendMailJob`. Defaults to `MailTransport` as CakePHP does.

Initially I thought it would be a good idea config to be:

```
'default' => [
    'options' => QUEUE_OPTIONS
    'transport' => [
        'className' => TRANSPORT_CLASS_NAME,
        'config' => TRANSPORT_CONFIG_ARRAY
    ]
]
```

But to make it as simple as possible, using the existing `config` and just switching the `className` to `QueueTransport` and adding the actual `transport` is better.

Please let me know your thoughts and if everybody is ok with this change I will implement the unit tests.

Thank you! 