### PR TITLE
Add support for unique jobs

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -59,6 +59,16 @@ The following configuration should be present in the config array of your **conf
 
             // Whether to store failed jobs in the queue_failed_jobs table. default: false
             'storeFailedJobs' => true,
+
+            // (optional) The cache configuration for storing unique job ids. `duration`
+            // should be greater than the maximum length of time any job can be expected
+            // to remain on the queue. Otherwise, duplicate jobs may be
+            // possible. Defaults to +24 hours. Note that `File` engine is only suitable
+            // for local development.
+            // See https://book.cakephp.org/4/en/core-libraries/caching.html#configuring-cache-engines.
+            'uniqueCache' => [
+                'engine' => 'File',
+            ],
         ]
     ],
     // ...
@@ -111,6 +121,13 @@ Create a Job class::
          */
         public static $maxAttempts = 3;
 
+        /**
+         * Whether there should be only one instance of a job on the queue at a time. (optional property)
+         * 
+         * @var bool
+         */
+        public static $shouldBeUnique = false;
+
         public function execute(Message $message): ?string
         {
             $id = $message->getArgument('id');
@@ -151,6 +168,12 @@ Properties:
   provided, this value will override the value provided in the worker command
   line option ``--max-attempts``. If a value is not provided by the job or by
   the command line option, the job may be requeued an infinite number of times.
+- ``shouldBeUnique``: If ``true``, only one instance of the job, identified by
+  it's class, method, and data, will be allowed to be present on the queue at a
+  time. Subsequent pushes will be silently dropped. This is useful for
+  idempotent operations where consecutive job executions have no benefit. For
+  example, refreshing calculated data. If ``true``, the ``uniqueCache``
+  configuration must be set.
 
 Queueing
 --------

--- a/src/Command/JobCommand.php
+++ b/src/Command/JobCommand.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Queue\Command;
 
 use Bake\Command\SimpleBakeCommand;
+use Cake\Console\Arguments;
 use Cake\Console\ConsoleOptionParser;
 
 class JobCommand extends SimpleBakeCommand
@@ -48,6 +49,20 @@ class JobCommand extends SimpleBakeCommand
     }
 
     /**
+     * @inheritDoc
+     */
+    public function templateData(Arguments $arguments): array
+    {
+        $parentData = parent::templateData($arguments);
+
+        $data = [
+            'isUnique' => $arguments->getOption('unique'),
+        ];
+
+        return array_merge($parentData, $data);
+    }
+
+    /**
      * Gets the option parser instance and configures it.
      *
      * @param \Cake\Console\ConsoleOptionParser $parser The parser to update.
@@ -61,6 +76,11 @@ class JobCommand extends SimpleBakeCommand
             ->setDescription('Bake a queue job class.')
             ->addArgument('name', [
                 'help' => 'The name of the queue job class to create.',
+            ])
+            ->addOption('unique', [
+                'help' => 'Whether there should be only one instance of a job on the queue at a time.',
+                'boolean' => true,
+                'default' => false,
             ]);
     }
 }

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -24,6 +24,7 @@ use Cake\Core\Configure;
 use Cake\Log\Log;
 use Cake\Queue\Consumption\LimitAttemptsExtension;
 use Cake\Queue\Consumption\LimitConsumedMessagesExtension;
+use Cake\Queue\Consumption\RemoveUniqueJobIdFromCacheExtension;
 use Cake\Queue\Listener\FailedJobsListener;
 use Cake\Queue\Queue\Processor;
 use Cake\Queue\QueueManager;
@@ -117,6 +118,7 @@ class WorkerCommand extends Command
         $extensions = [
             new LoggerExtension($logger),
             $limitAttempsExtension,
+            new RemoveUniqueJobIdFromCacheExtension('Cake/Queue.queueUnique'),
         ];
 
         if (!is_null($args->getOption('max-jobs'))) {

--- a/src/Consumption/RemoveUniqueJobIdFromCacheExtension.php
+++ b/src/Consumption/RemoveUniqueJobIdFromCacheExtension.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Queue\Consumption;
+
+use Cake\Cache\Cache;
+use Cake\Queue\Job\Message;
+use Cake\Queue\QueueManager;
+use Enqueue\Consumption\Context\MessageResult;
+use Enqueue\Consumption\MessageResultExtensionInterface;
+
+class RemoveUniqueJobIdFromCacheExtension implements MessageResultExtensionInterface
+{
+    /**
+     * Cache engine name.
+     *
+     * @var string
+     */
+    protected $cache;
+
+    /**
+     * @param string $cache Cache engine name.
+     * @return void
+     */
+    public function __construct(string $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * @param \Enqueue\Consumption\Context\MessageResult $context The result of the message after it was processed.
+     * @return void
+     */
+    public function onResult(MessageResult $context): void
+    {
+        $message = $context->getMessage();
+
+        $jobMessage = new Message($message, $context->getContext());
+
+        /** @psalm-var class-string $class */
+        [$class, $method] = $jobMessage->getTarget();
+
+        if (empty($class::$shouldBeUnique)) {
+            return;
+        }
+
+        $data = $jobMessage->getArgument();
+
+        $uniqueId = QueueManager::getUniqueId($class, $method, $data);
+
+        Cache::delete($uniqueId, $this->cache);
+    }
+}

--- a/src/Consumption/RemoveUniqueJobIdFromCacheExtension.php
+++ b/src/Consumption/RemoveUniqueJobIdFromCacheExtension.php
@@ -37,9 +37,9 @@ class RemoveUniqueJobIdFromCacheExtension implements MessageResultExtensionInter
 
         $jobMessage = new Message($message, $context->getContext());
 
-        /** @psalm-var class-string $class */
         [$class, $method] = $jobMessage->getTarget();
 
+        /** @psalm-suppress InvalidPropertyFetch */
         if (empty($class::$shouldBeUnique)) {
             return;
         }

--- a/src/Job/Message.php
+++ b/src/Job/Message.php
@@ -104,7 +104,8 @@ class Message implements JsonSerializable
     /**
      * Get the target class and method.
      *
-     * @return array
+     * @return array{string, string}
+     * @psalm-return array{class-string, string}
      */
     public function getTarget(): array
     {
@@ -150,6 +151,7 @@ class Message implements JsonSerializable
     {
         $target = $this->getTarget();
 
+        /** @psalm-var class-string $class */
         $class = $target[0];
 
         return $class::$maxAttempts ?? null;

--- a/src/Job/Message.php
+++ b/src/Job/Message.php
@@ -151,9 +151,9 @@ class Message implements JsonSerializable
     {
         $target = $this->getTarget();
 
-        /** @psalm-var class-string $class */
         $class = $target[0];
 
+        /** @psalm-suppress InvalidPropertyFetch */
         return $class::$maxAttempts ?? null;
     }
 

--- a/src/Listener/FailedJobsListener.php
+++ b/src/Listener/FailedJobsListener.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
  */
 namespace Cake\Queue\Listener;
 
-use Cake\Event\EventInterface;
 use Cake\Event\EventListenerInterface;
 use Cake\ORM\Exception\PersistenceFailedException;
 use Cake\ORM\Locator\LocatorAwareTrait;
@@ -39,10 +38,10 @@ class FailedJobsListener implements EventListenerInterface
     }
 
     /**
-     * @param \Cake\Event\EventInterface $event EventInterface
+     * @param object $event EventInterface.
      * @return void
      */
-    public function storeFailedJob(EventInterface $event): void
+    public function storeFailedJob($event): void
     {
         /** @var \Cake\Queue\Job\Message $jobMessage */
         $jobMessage = $event->getSubject();

--- a/src/QueueManager.php
+++ b/src/QueueManager.php
@@ -275,6 +275,7 @@ class QueueManager
         $client = static::engine($name);
         $client->sendEvent($queue, $message);
 
+        /** @psalm-suppress InvalidPropertyFetch */
         if (!empty($class::$shouldBeUnique)) {
             $uniqueId = static::getUniqueId($class, $method, $data);
 

--- a/src/QueueManager.php
+++ b/src/QueueManager.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Cake\Queue;
 
 use BadMethodCallException;
+use Cake\Cache\Cache;
 use Cake\Core\App;
 use Cake\Log\Log;
 use Enqueue\Client\Message as ClientMessage;
@@ -119,6 +120,16 @@ class QueueManager
             }
         }
 
+        if (!empty($config['uniqueCache'])) {
+            $cacheDefaults = [
+                'duration' => '+24 hours',
+            ];
+
+            $cacheConfig = array_merge($cacheDefaults, $config['uniqueCache']);
+
+            Cache::setConfig('Cake/Queue.queueUnique', $cacheConfig);
+        }
+
         /** @psalm-suppress InvalidPropertyAssignmentValue */
         static::$_config[$key] = $config;
     }
@@ -209,7 +220,33 @@ class QueueManager
 
         $name = $options['config'] ?? 'default';
 
-        $config = static::getConfig($name);
+        $config = static::getConfig($name) + [
+            'logger' => null,
+        ];
+
+        $logger = $config['logger'] ? Log::engine($config['logger']) : null;
+
+        /** @psalm-suppress InvalidPropertyFetch */
+        if (!empty($class::$shouldBeUnique)) {
+            if (!Cache::getConfig('Cake/Queue.queueUnique')) {
+                throw new InvalidArgumentException(
+                    "$class::\$shouldBeUnique is set to `true` but `uniqueCache` configuration is missing."
+                );
+            }
+
+            $uniqueId = static::getUniqueId($class, $method, $data);
+
+            if (Cache::read($uniqueId, 'Cake/Queue.queueUnique')) {
+                if ($logger) {
+                    $logger->debug(
+                        "An identical instance of $class already exists on the queue. This push will be ignored."
+                    );
+                }
+
+                return;
+            }
+        }
+
         $queue = $options['queue'] ?? $config['queue'] ?? 'default';
 
         $message = new ClientMessage([
@@ -237,5 +274,30 @@ class QueueManager
 
         $client = static::engine($name);
         $client->sendEvent($queue, $message);
+
+        if (!empty($class::$shouldBeUnique)) {
+            $uniqueId = static::getUniqueId($class, $method, $data);
+
+            Cache::add($uniqueId, true, 'Cake/Queue.queueUnique');
+        }
+    }
+
+    /**
+     * @param string $class Class name
+     * @param string $method Method name
+     * @param array $data Message data
+     * @return string
+     */
+    public static function getUniqueId(string $class, string $method, array $data): string
+    {
+        sort($data);
+
+        $hashInput = implode([
+            $class,
+            $method,
+            json_encode($data),
+        ]);
+
+        return hash('md5', $hashInput);
     }
 }

--- a/templates/bake/job.twig
+++ b/templates/bake/job.twig
@@ -34,6 +34,15 @@ class {{ name }}Job implements JobInterface
      */
     public static $maxAttempts = 3;
 
+{% if isUnique %}
+    /**
+     * Whether there should be only one instance of a job on the queue at a time. (optional property)
+     * 
+     * @var bool
+     */
+    public static $shouldBeUnique = true;
+
+{% endif %}
     /**
      * Executes logic for {{ name }}Job
      *

--- a/tests/TestCase/Consumption/LimitAttemptsExtensionTest.php
+++ b/tests/TestCase/Consumption/LimitAttemptsExtensionTest.php
@@ -40,7 +40,7 @@ class LimitAttemptsExtensionTest extends TestCase
 
     public function testMessageShouldBeRequeuedIfMaxAttemptsIsNotSet()
     {
-        $consume = $this->setupQeueue();
+        $consume = $this->setupQueue();
 
         QueueManager::push(RequeueJob::class);
 
@@ -52,7 +52,7 @@ class LimitAttemptsExtensionTest extends TestCase
 
     public function testFailedEventIsFiredWhenMaxAttemptsIsExceeded()
     {
-        $consume = $this->setupQeueue();
+        $consume = $this->setupQueue();
 
         QueueManager::push(MaxAttemptsIsThreeJob::class, []);
 
@@ -63,7 +63,7 @@ class LimitAttemptsExtensionTest extends TestCase
 
     public function testMessageShouldBeRequeuedUntilMaxAttemptsIsReached()
     {
-        $consume = $this->setupQeueue();
+        $consume = $this->setupQueue();
 
         QueueManager::push(MaxAttemptsIsThreeJob::class, []);
 
@@ -74,7 +74,7 @@ class LimitAttemptsExtensionTest extends TestCase
 
     public function testMessageShouldBeRequeuedIfGlobalMaxAttemptsIsNotSet()
     {
-        $consume = $this->setupQeueue();
+        $consume = $this->setupQueue();
 
         QueueManager::push(RequeueJob::class);
 
@@ -86,7 +86,7 @@ class LimitAttemptsExtensionTest extends TestCase
 
     public function testMessageShouldBeRequeuedUntilGlobalMaxAttemptsIsReached()
     {
-        $consume = $this->setupQeueue([3]);
+        $consume = $this->setupQueue([3]);
 
         QueueManager::push(MaxAttemptsIsThreeJob::class, ['succeedAt' => 10]);
 
@@ -95,7 +95,7 @@ class LimitAttemptsExtensionTest extends TestCase
         $this->assertDebugLogContainsExactly('MaxAttemptsIsThreeJob is requeueing', 3);
     }
 
-    protected function setupQeueue($extensionArgs = [])
+    protected function setupQueue($extensionArgs = [])
     {
         Log::setConfig('debug', [
             'className' => 'Array',

--- a/tests/TestCase/Consumption/RemoveUniqueJobIdFromCacheExtensionTest.php
+++ b/tests/TestCase/Consumption/RemoveUniqueJobIdFromCacheExtensionTest.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace Cake\Queue\Test\TestCase\Job;
+
+use Cake\Cache\Cache;
+use Cake\Log\Log;
+use Cake\Queue\Consumption\LimitConsumedMessagesExtension;
+use Cake\Queue\Consumption\RemoveUniqueJobIdFromCacheExtension;
+use Cake\Queue\Queue\Processor as QueueProcessor;
+use Cake\Queue\QueueManager;
+use Cake\TestSuite\TestCase;
+use Enqueue\Consumption\ChainExtension;
+use Psr\Log\NullLogger;
+use TestApp\Job\UniqueJob;
+
+class RemoveUniqueJobIdFromCacheExtensionTest extends TestCase
+{
+    /**
+     * @beforeClass
+     * @after
+     */
+    public static function dropConfigs()
+    {
+        Log::drop('debug');
+
+        QueueManager::drop('default');
+
+        if (Cache::getConfig('Cake/Queue.queueUnique')) {
+            Cache::clear('Cake/Queue.queueUnique');
+            Cache::drop('Cake/Queue.queueUnique');
+        }
+    }
+
+    public function testJobIsRemovedFromCacheAfterProcessing()
+    {
+        $consume = $this->setupQueue();
+
+        QueueManager::push(UniqueJob::class, []);
+
+        $uniqueId = QueueManager::getUniqueId(UniqueJob::class, 'execute', []);
+        $this->assertTrue(Cache::read($uniqueId, 'Cake/Queue.queueUnique'));
+
+        $consume();
+
+        $this->assertNull(Cache::read($uniqueId, 'Cake/Queue.queueUnique'));
+    }
+
+    protected function setupQueue($extensionArgs = [])
+    {
+        Log::setConfig('debug', [
+            'className' => 'Array',
+            'levels' => ['debug'],
+        ]);
+
+        QueueManager::setConfig('default', [
+            'url' => 'file:///' . TMP . DS . uniqid('queue'),
+            'receiveTimeout' => 100,
+            'uniqueCache' => [
+                'engine' => 'File',
+            ],
+        ]);
+
+        $client = QueueManager::engine('default');
+
+        $processor = new QueueProcessor(new NullLogger());
+        $client->bindTopic('default', $processor);
+
+        $extension = new ChainExtension([
+            new LimitConsumedMessagesExtension(1),
+            new RemoveUniqueJobIdFromCacheExtension('Cake/Queue.queueUnique'),
+        ]);
+
+        return function () use ($client, $extension) {
+            $client->consume($extension);
+        };
+    }
+}

--- a/tests/TestCase/Task/JobTaskTest.php
+++ b/tests/TestCase/Task/JobTaskTest.php
@@ -72,4 +72,18 @@ class JobTaskTest extends TestCase
             file_get_contents($this->generatedFile)
         );
     }
+
+    public function testMainWithUnique()
+    {
+        $this->generatedFile = APP . 'Job' . DS . 'UploadJob.php';
+
+        $this->exec('bake job upload --unique');
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertFileExists($this->generatedFile);
+        $this->assertOutputContains('Creating file ' . $this->generatedFile);
+        $this->assertSameAsFile(
+            $this->comparisonDir . 'JobTaskWithUnique.php',
+            file_get_contents($this->generatedFile)
+        );
+    }
 }

--- a/tests/comparisons/JobTaskWithUnique.php
+++ b/tests/comparisons/JobTaskWithUnique.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Job;
+
+use Cake\Queue\Job\JobInterface;
+use Cake\Queue\Job\Message;
+use Interop\Queue\Processor;
+
+/**
+ * Upload job
+ */
+class UploadJob implements JobInterface
+{
+    /**
+     * The maximum number of times the job may be attempted.
+     * 
+     * @var int|null
+     */
+    public static $maxAttempts = 3;
+
+    /**
+     * Whether there should be only one instance of a job on the queue at a time. (optional property)
+     * 
+     * @var bool
+     */
+    public static $shouldBeUnique = true;
+
+    /**
+     * Executes logic for UploadJob
+     *
+     * @param \Cake\Queue\Job\Message $message job message
+     * @return string|null
+     */
+    public function execute(Message $message): ?string
+    {
+        return Processor::ACK;
+    }
+}

--- a/tests/test_app/src/Job/UniqueJob.php
+++ b/tests/test_app/src/Job/UniqueJob.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Job;
+
+use Cake\Log\Log;
+use Cake\Queue\Job\JobInterface;
+use Cake\Queue\Job\Message;
+use Interop\Queue\Processor;
+
+class UniqueJob implements JobInterface
+{
+    public static $shouldBeUnique = true;
+
+    public function execute(Message $message): ?string
+    {
+        Log::debug('Unique job was run');
+
+        return Processor::ACK;
+    }
+}


### PR DESCRIPTION
This adds support for queueing unique jobs. When enabled for a given job, it will be (nearly) guaranteed that no other jobs with the same data will be present on the queue simultaneously.

Sometimes when the same job with the same payload is queued multiple times before other instances of the job are able to be run, it's not useful to run the job multiple times, once is enough, so this aims to address that.

