### PR TITLE
Set Exception as Property on Message

### DIFF
--- a/src/Consumption/LimitAttemptsExtension.php
+++ b/src/Consumption/LimitAttemptsExtension.php
@@ -61,13 +61,11 @@ class LimitAttemptsExtension implements MessageResultExtensionInterface
         $attemptNumber = $message->getProperty(self::ATTEMPTS_PROPERTY, 0) + 1;
 
         if ($attemptNumber >= $maxAttempts) {
-            $originalResult = $context->getResult();
-
             $context->changeResult(
                 Result::reject(sprintf('The maximum number of %d allowed attempts was reached.', $maxAttempts))
             );
 
-            $exception = $originalResult instanceof Result ? $originalResult->getReason() : null;
+            $exception = (string)$message->getProperty('jobException');
 
             $this->dispatchEvent(
                 'Consumption.LimitAttemptsExtension.failed',

--- a/src/Queue/Processor.php
+++ b/src/Queue/Processor.php
@@ -81,13 +81,15 @@ class Processor implements InteropProcessor
         try {
             $response = $this->processMessage($jobMessage);
         } catch (Throwable $e) {
+            $message->setProperty('jobException', $e);
+
             $this->logger->debug(sprintf('Message encountered exception: %s', $e->getMessage()));
             $this->dispatchEvent('Processor.message.exception', [
                 'message' => $jobMessage,
                 'exception' => $e,
             ]);
 
-            return Result::requeue(sprintf('Exception occurred while processing message: %s', (string)$e));
+            return Result::requeue('Exception occurred while processing message');
         }
 
         if ($response === InteropProcessor::ACK) {


### PR DESCRIPTION
This allows the exception to be saved to the queue_failed_jobs table without the reason prefix.

Fixes #114