### PR TITLE
Use unique names for queue unique cache configurations

### DIFF
--- a/tests/TestCase/Command/WorkerCommandTest.php
+++ b/tests/TestCase/Command/WorkerCommandTest.php
@@ -299,4 +299,31 @@ class WorkerCommandTest extends TestCase
 
         $this->assertDebugLogContains('Debug job was run with service infotext');
     }
+
+    /**
+     * Test that queue will process when a unique cache is configured.
+     *
+     * @runInSeparateProcess
+     */
+    public function testQueueProcessesWithUniqueCacheConfigured()
+    {
+        $config = [
+            'queue' => 'default',
+            'url' => 'file:///' . TMP . DS . 'queue',
+            'receiveTimeout' => 100,
+            'uniqueCache' => [
+                'engine' => 'File',
+            ],
+        ];
+        Configure::write('Queue', ['default' => $config]);
+
+        Log::setConfig('debug', [
+            'className' => 'Array',
+            'levels' => ['notice', 'info', 'debug'],
+        ]);
+
+        $this->exec('queue worker --max-jobs=1 --logger=debug --verbose');
+
+        $this->assertDebugLogContains('Consumption has started');
+    }
 }


### PR DESCRIPTION
Prevents an exception when multiple configs are set with `uniqueCache` configured.

Fixes #113