### PR TITLE
Make max attempts optional in bake job command

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -118,7 +118,7 @@ A simple job that logs received messages would look like::
         use LogTrait;
 
         /**
-         * The maximum number of times the job may be attempted.
+         * The maximum number of times the job may be attempted. (optional property)
          * 
          * @var int|null
          */

--- a/src/Command/JobCommand.php
+++ b/src/Command/JobCommand.php
@@ -55,8 +55,11 @@ class JobCommand extends SimpleBakeCommand
     {
         $parentData = parent::templateData($arguments);
 
+        $maxAttempts = $arguments->getOption('max-attempts');
+
         $data = [
             'isUnique' => $arguments->getOption('unique'),
+            'maxAttempts' => $maxAttempts ? (int)$maxAttempts : null,
         ];
 
         return array_merge($parentData, $data);
@@ -76,6 +79,10 @@ class JobCommand extends SimpleBakeCommand
             ->setDescription('Bake a queue job class.')
             ->addArgument('name', [
                 'help' => 'The name of the queue job class to create.',
+            ])
+            ->addOption('max-attempts', [
+                'help' => 'The maximum number of times the job may be attempted.',
+                'default' => null,
             ])
             ->addOption('unique', [
                 'help' => 'Whether there should be only one instance of a job on the queue at a time.',

--- a/templates/bake/job.twig
+++ b/templates/bake/job.twig
@@ -27,13 +27,15 @@ use Interop\Queue\Processor;
  */
 class {{ name }}Job implements JobInterface
 {
+{% if maxAttempts %}
     /**
      * The maximum number of times the job may be attempted.
      * 
      * @var int|null
      */
-    public static $maxAttempts = 3;
+    public static $maxAttempts = {{ maxAttempts }};
 
+{% endif %}
 {% if isUnique %}
     /**
      * Whether there should be only one instance of a job on the queue at a time. (optional property)

--- a/tests/TestCase/Task/JobTaskTest.php
+++ b/tests/TestCase/Task/JobTaskTest.php
@@ -86,4 +86,18 @@ class JobTaskTest extends TestCase
             file_get_contents($this->generatedFile)
         );
     }
+
+    public function testMainWithMaxAttempts()
+    {
+        $this->generatedFile = APP . 'Job' . DS . 'UploadJob.php';
+
+        $this->exec('bake job upload --max-attempts 3');
+        $this->assertExitCode(Command::CODE_SUCCESS);
+        $this->assertFileExists($this->generatedFile);
+        $this->assertOutputContains('Creating file ' . $this->generatedFile);
+        $this->assertSameAsFile(
+            $this->comparisonDir . 'JobTaskWithMaxAttempts.php',
+            file_get_contents($this->generatedFile)
+        );
+    }
 }

--- a/tests/comparisons/JobTaskWithMaxAttempts.php
+++ b/tests/comparisons/JobTaskWithMaxAttempts.php
@@ -13,6 +13,13 @@ use Interop\Queue\Processor;
 class UploadJob implements JobInterface
 {
     /**
+     * The maximum number of times the job may be attempted.
+     * 
+     * @var int|null
+     */
+    public static $maxAttempts = 3;
+
+    /**
      * Executes logic for UploadJob
      *
      * @param \Cake\Queue\Job\Message $message job message

--- a/tests/comparisons/JobTaskWithUnique.php
+++ b/tests/comparisons/JobTaskWithUnique.php
@@ -13,13 +13,6 @@ use Interop\Queue\Processor;
 class UploadJob implements JobInterface
 {
     /**
-     * The maximum number of times the job may be attempted.
-     * 
-     * @var int|null
-     */
-    public static $maxAttempts = 3;
-
-    /**
      * Whether there should be only one instance of a job on the queue at a time. (optional property)
      * 
      * @var bool


### PR DESCRIPTION
This makes including `maxAttempts` optional when baking jobs similar to `shouldBeUnique`. Specifying the option `--max-attempts [number of attempts]` will include the property in the baked job, otherwise the property won't be included.