### PR TITLE
Add default processor if argument is not passed to avoid processor hash

### DIFF
--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -204,7 +204,7 @@ class WorkerCommand extends Command
         $queue = $args->getOption('queue')
             ? (string)$args->getOption('queue')
             : Configure::read("Queue.{$config}.queue", 'default');
-        $processorName = $args->getOption('processor') ? (string)$args->getOption('processor') : null;
+        $processorName = $args->getOption('processor') ? (string)$args->getOption('processor') : 'default';
 
         $client->bindTopic($queue, $processor, $processorName);
         $client->consume($extension);


### PR DESCRIPTION
Fixes #95 ...After adding the parameter processor the issue with enqueue is fixed but we should allow having a default so people don't actually need to pass processor param.

Please let me know your thoughts

