### PR TITLE
port over `enqueue/simple-client`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,12 @@
     },
     "require": {
         "php": ">=8.1",
-        "cakephp/cakephp": "dev-5.next as 5.1.0",
-        "enqueue/simple-client": "^0.10",
-        "psr/log": "^3.0"
+        "cakephp/cakephp": "^5.1.0",
+        "psr/log": "^3.0",
+        "enqueue/enqueue": "^0.10",
+        "queue-interop/amqp-interop": "^0.8.2",
+        "queue-interop/queue-interop": "^0.8",
+        "symfony/config": "^5.4|^6.0|^7.0"
     },
     "require-dev": {
         "cakephp/bake": "dev-3.next",

--- a/src/Command/RequeueCommand.php
+++ b/src/Command/RequeueCommand.php
@@ -138,7 +138,7 @@ class RequeueCommand extends Command
                         'config' => $failedJob->config,
                         'priority' => $failedJob->priority,
                         'queue' => $failedJob->queue,
-                    ]
+                    ],
                 );
 
                 $failedJobsTable->deleteOrFail($failedJob);

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -110,7 +110,7 @@ class WorkerCommand extends Command
             'short' => 'a',
         ]);
         $parser->setDescription(
-            'Runs a queue worker that consumes from the named queue.'
+            'Runs a queue worker that consumes from the named queue.',
         );
 
         return $parser;

--- a/src/Consumption/LimitAttemptsExtension.php
+++ b/src/Consumption/LimitAttemptsExtension.php
@@ -65,7 +65,7 @@ class LimitAttemptsExtension implements MessageResultExtensionInterface
 
         if ($attemptNumber >= $maxAttempts) {
             $context->changeResult(
-                Result::reject(sprintf('The maximum number of %d allowed attempts was reached.', $maxAttempts))
+                Result::reject(sprintf('The maximum number of %d allowed attempts was reached.', $maxAttempts)),
             );
 
             $exception = (string)$message->getProperty('jobException');
@@ -73,7 +73,7 @@ class LimitAttemptsExtension implements MessageResultExtensionInterface
             $this->dispatchEvent(
                 'Consumption.LimitAttemptsExtension.failed',
                 ['exception' => $exception, 'logger' => $context->getLogger()],
-                $jobMessage
+                $jobMessage,
             );
 
             return;
@@ -88,7 +88,7 @@ class LimitAttemptsExtension implements MessageResultExtensionInterface
         $producer->send($consumer->getQueue(), $newMessage);
 
         $context->changeResult(
-            Result::reject('A copy of the message was sent with an incremented attempt count.')
+            Result::reject('A copy of the message was sent with an incremented attempt count.'),
         );
     }
 }

--- a/src/Consumption/LimitConsumedMessagesExtension.php
+++ b/src/Consumption/LimitConsumedMessagesExtension.php
@@ -79,7 +79,7 @@ class LimitConsumedMessagesExtension implements PreConsumeExtensionInterface, Po
             $logger->debug(sprintf(
                 '[LimitConsumedMessagesExtension] Message consumption is interrupted since the message limit ' .
                 'reached. limit: "%s"',
-                $this->messageLimit
+                $this->messageLimit,
             ));
 
             return true;

--- a/src/Enqueue/SimpleClient.php
+++ b/src/Enqueue/SimpleClient.php
@@ -1,0 +1,403 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       https://opensource.org/licenses/MIT MIT License
+ */
+namespace Cake\Queue\Enqueue;
+
+use Enqueue\ArrayProcessorRegistry;
+use Enqueue\Client\ChainExtension as ClientChainExtensions;
+use Enqueue\Client\Config;
+use Enqueue\Client\ConsumptionExtension\DelayRedeliveredMessageExtension;
+use Enqueue\Client\ConsumptionExtension\LogExtension;
+use Enqueue\Client\ConsumptionExtension\SetRouterPropertiesExtension;
+use Enqueue\Client\DelegateProcessor;
+use Enqueue\Client\DriverFactory;
+use Enqueue\Client\DriverInterface;
+use Enqueue\Client\Message;
+use Enqueue\Client\Producer;
+use Enqueue\Client\ProducerInterface;
+use Enqueue\Client\Route;
+use Enqueue\Client\RouteCollection;
+use Enqueue\Client\RouterProcessor;
+use Enqueue\ConnectionFactoryFactory;
+use Enqueue\Consumption\CallbackProcessor;
+use Enqueue\Consumption\ChainExtension as ConsumptionChainExtension;
+use Enqueue\Consumption\Extension\ReplyExtension;
+use Enqueue\Consumption\Extension\SignalExtension;
+use Enqueue\Consumption\ExtensionInterface;
+use Enqueue\Consumption\QueueConsumer;
+use Enqueue\Consumption\QueueConsumerInterface;
+use Enqueue\Rpc\Promise;
+use Enqueue\Rpc\RpcFactory;
+use Enqueue\Symfony\Client\DependencyInjection\ClientFactory;
+use Enqueue\Symfony\DependencyInjection\TransportFactory;
+use Interop\Queue\Processor;
+use JsonSerializable;
+use LogicException;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\NodeInterface;
+use Symfony\Component\Config\Definition\Processor as ConfigProcessor;
+
+class SimpleClient
+{
+    /**
+     * @var \Enqueue\Client\DriverInterface
+     */
+    private DriverInterface $driver;
+
+    /**
+     * @var \Enqueue\Client\Producer
+     */
+    private Producer $producer;
+
+    /**
+     * @var \Enqueue\Consumption\QueueConsumer
+     */
+    private QueueConsumer $queueConsumer;
+
+    /**
+     * @var \Enqueue\ArrayProcessorRegistry
+     */
+    private ArrayProcessorRegistry $processorRegistry;
+
+    /**
+     * @var \Enqueue\Client\DelegateProcessor
+     */
+    private DelegateProcessor $delegateProcessor;
+
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    private LoggerInterface $logger;
+
+    /**
+     * The config could be a transport DSN (string) or an array, here's an example of a few DSNs:.
+     *
+     * $config = amqp:
+     * $config = amqp://guest:guest@localhost:5672/%2f?lazy=1&persisted=1
+     * $config = file://foo/bar/
+     * $config = null:
+     *
+     * or an array:
+     *
+     * $config = [
+     *   'transport' => [
+     *      'dsn' => 'amqps://guest:guest@localhost:5672/%2f',
+     *      'ssl_cacert' => '/a/dir/cacert.pem',
+     *      'ssl_cert' => '/a/dir/cert.pem',
+     *      'ssl_key' => '/a/dir/key.pem',
+     * ]
+     *
+     * with custom connection factory class
+     *
+     * $config = [
+     *   'transport' => [
+     *      'dsn' => 'amqps://guest:guest@localhost:5672/%2f',
+     *      'connection_factory_class' => 'aCustomConnectionFactory',
+     *      // other options available options are factory_class and factory_service
+     * ]
+     *
+     * The client config
+     *
+     * $config = [
+     *   'transport' => 'null:',
+     *   'client' => [
+     *     'prefix'                   => 'enqueue',
+     *     'separator'                => '.',
+     *     'app_name'                 => 'app',
+     *     'router_topic'             => 'router',
+     *     'router_queue'             => 'default',
+     *     'default_queue'            => 'default',
+     *     'redelivered_delay_time'   => 0
+     *   ],
+     *   'extensions' => [
+     *     'signal_extension' => true,
+     *     'reply_extension' => true,
+     *   ]
+     * ]
+     *
+     * @param array|string $config
+     * @param \Psr\Log\LoggerInterface|null $logger
+     */
+    public function __construct(string|array $config, ?LoggerInterface $logger = null)
+    {
+        if (is_string($config)) {
+            $config = [
+                'transport' => $config,
+                'client' => true,
+            ];
+        }
+
+        $this->logger = $logger ?: new NullLogger();
+
+        $this->build(['enqueue' => $config]);
+    }
+
+    /**
+     * @param string $topic
+     * @param \Interop\Queue\Processor|callable $processor
+     * @param string|null $processorName
+     */
+    public function bindTopic(string $topic, callable|Processor $processor, ?string $processorName = null): void
+    {
+        if (is_callable($processor)) {
+            $processor = new CallbackProcessor($processor);
+        }
+
+        if (!$processor instanceof Processor) {
+            throw new LogicException('The processor must be either callable or instance of Processor');
+        }
+
+        $processorName = $processorName ?: uniqid($processor::class);
+
+        $this->driver->getRouteCollection()->add(new Route($topic, Route::TOPIC, $processorName));
+        $this->processorRegistry->add($processorName, $processor);
+    }
+
+    /**
+     * @param string $command
+     * @param \Interop\Queue\Processor|callable $processor
+     * @param string|null $processorName
+     */
+    public function bindCommand(string $command, callable|Processor $processor, ?string $processorName = null): void
+    {
+        if (is_callable($processor)) {
+            $processor = new CallbackProcessor($processor);
+        }
+
+        if (!$processor instanceof Processor) {
+            throw new LogicException('The processor must be either callable or instance of Processor');
+        }
+
+        $processorName = $processorName ?: uniqid($processor::class);
+
+        $this->driver->getRouteCollection()->add(new Route($command, Route::COMMAND, $processorName));
+        $this->processorRegistry->add($processorName, $processor);
+    }
+
+    /**
+     * @param string $command
+     * @param \JsonSerializable|\Enqueue\Client\Message|array|string $message
+     * @param bool $needReply
+     * @return \Enqueue\Rpc\Promise|null
+     * @throws \Exception
+     */
+    public function sendCommand(
+        string $command,
+        string|array|JsonSerializable|Message $message,
+        bool $needReply = false,
+    ): ?Promise {
+        return $this->producer->sendCommand($command, $message, $needReply);
+    }
+
+    /**
+     * @param string $topic
+     * @param \Enqueue\Client\Message|array|string $message
+     * @throws \Exception
+     */
+    public function sendEvent(string $topic, string|array|Message $message): void
+    {
+        $this->producer->sendEvent($topic, $message);
+    }
+
+    /**
+     * @param \Enqueue\Consumption\ExtensionInterface|null $runtimeExtension
+     * @return void
+     * @throws \Exception
+     */
+    public function consume(?ExtensionInterface $runtimeExtension = null): void
+    {
+        $this->setupBroker();
+
+        $boundQueues = [];
+
+        $routerQueue = $this->getDriver()->createQueue($this->getDriver()->getConfig()->getRouterQueue());
+        $this->queueConsumer->bind($routerQueue, $this->delegateProcessor);
+        $boundQueues[$routerQueue->getQueueName()] = true;
+
+        foreach ($this->driver->getRouteCollection()->all() as $route) {
+            $queue = $this->getDriver()->createRouteQueue($route);
+            if (array_key_exists($queue->getQueueName(), $boundQueues)) {
+                continue;
+            }
+
+            $this->queueConsumer->bind($queue, $this->delegateProcessor);
+
+            $boundQueues[$queue->getQueueName()] = true;
+        }
+
+        $this->queueConsumer->consume($runtimeExtension);
+    }
+
+    /**
+     * @return \Enqueue\Consumption\QueueConsumerInterface
+     */
+    public function getQueueConsumer(): QueueConsumerInterface
+    {
+        return $this->queueConsumer;
+    }
+
+    /**
+     * @return \Enqueue\Client\DriverInterface
+     */
+    public function getDriver(): DriverInterface
+    {
+        return $this->driver;
+    }
+
+    /**
+     * @param bool $setupBroker
+     * @return \Enqueue\Client\ProducerInterface
+     */
+    public function getProducer(bool $setupBroker = false): ProducerInterface
+    {
+        $setupBroker && $this->setupBroker();
+
+        return $this->producer;
+    }
+
+    /**
+     * @return \Enqueue\Client\DelegateProcessor
+     */
+    public function getDelegateProcessor(): DelegateProcessor
+    {
+        return $this->delegateProcessor;
+    }
+
+    /**
+     * @return void
+     */
+    public function setupBroker(): void
+    {
+        $this->getDriver()->setupBroker();
+    }
+
+    /**
+     * @param array $configs
+     * @return void
+     */
+    public function build(array $configs): void
+    {
+        $configProcessor = new ConfigProcessor();
+        $simpleClientConfig = $configProcessor->process($this->createConfiguration(), $configs);
+
+        if (isset($simpleClientConfig['transport']['factory_service'])) {
+            throw new LogicException('transport.factory_service option is not supported by simple client');
+        }
+        if (isset($simpleClientConfig['transport']['factory_class'])) {
+            throw new LogicException('transport.factory_class option is not supported by simple client');
+        }
+        if (isset($simpleClientConfig['transport']['connection_factory_class'])) {
+            throw new LogicException('transport.connection_factory_class option is not supported by simple client');
+        }
+
+        $connectionFactoryFactory = new ConnectionFactoryFactory();
+        $connection = $connectionFactoryFactory->create($simpleClientConfig['transport']);
+
+        $clientExtensions = new ClientChainExtensions([]);
+
+        $config = new Config(
+            $simpleClientConfig['client']['prefix'],
+            $simpleClientConfig['client']['separator'],
+            $simpleClientConfig['client']['app_name'],
+            $simpleClientConfig['client']['router_topic'],
+            $simpleClientConfig['client']['router_queue'],
+            $simpleClientConfig['client']['default_queue'],
+            'enqueue.client.router_processor',
+            $simpleClientConfig['transport'],
+            [],
+        );
+
+        $routeCollection = new RouteCollection([]);
+        $driverFactory = new DriverFactory();
+
+        $driver = $driverFactory->create(
+            $connection,
+            $config,
+            $routeCollection,
+        );
+
+        $rpcFactory = new RpcFactory($driver->getContext());
+
+        $producer = new Producer($driver, $rpcFactory, $clientExtensions);
+
+        $processorRegistry = new ArrayProcessorRegistry([]);
+
+        $delegateProcessor = new DelegateProcessor($processorRegistry);
+
+        // consumption extensions
+        $consumptionExtensions = [];
+        if ($simpleClientConfig['client']['redelivered_delay_time']) {
+            $consumptionExtensions[] = new DelayRedeliveredMessageExtension(
+                $driver,
+                $simpleClientConfig['client']['redelivered_delay_time'],
+            );
+        }
+
+        if ($simpleClientConfig['extensions']['signal_extension']) {
+            $consumptionExtensions[] = new SignalExtension();
+        }
+
+        if ($simpleClientConfig['extensions']['reply_extension']) {
+            $consumptionExtensions[] = new ReplyExtension();
+        }
+
+        $consumptionExtensions[] = new SetRouterPropertiesExtension($driver);
+        $consumptionExtensions[] = new LogExtension();
+
+        $consumptionChainExtension = new ConsumptionChainExtension($consumptionExtensions);
+        $queueConsumer = new QueueConsumer($driver->getContext(), $consumptionChainExtension, [], $this->logger);
+
+        $routerProcessor = new RouterProcessor($driver);
+
+        $processorRegistry->add($config->getRouterProcessor(), $routerProcessor);
+
+        $this->driver = $driver;
+        $this->producer = $producer;
+        $this->queueConsumer = $queueConsumer;
+        $this->delegateProcessor = $delegateProcessor;
+        $this->processorRegistry = $processorRegistry;
+    }
+
+    /**
+     * @return \Symfony\Component\Config\Definition\NodeInterface
+     */
+    private function createConfiguration(): NodeInterface
+    {
+        $tb = new TreeBuilder('enqueue');
+        $rootNode = $tb->getRootNode();
+
+        $rootNode
+            ->beforeNormalization()
+            ->ifEmpty()->then(function () {
+                return ['transport' => ['dsn' => 'null:']];
+            });
+
+        $rootNode
+            ->append(TransportFactory::getConfiguration())
+            ->append(TransportFactory::getQueueConsumerConfiguration())
+            ->append(ClientFactory::getConfiguration(false));
+
+        $rootNode->children()
+            ->arrayNode('extensions')->addDefaultsIfNotSet()->children()
+            ->booleanNode('signal_extension')->defaultValue(function_exists('pcntl_signal_dispatch'))->end()
+            ->booleanNode('reply_extension')->defaultTrue()->end()
+            ->end();
+
+        return $tb->buildTree();
+    }
+}

--- a/src/Job/Message.php
+++ b/src/Job/Message.php
@@ -114,7 +114,7 @@ class Message implements JsonSerializable
         if (!is_array($target) || count($target) !== 2) {
             throw new RuntimeException(sprintf(
                 'Message class should be in the form `[class, method]` got `%s`',
-                json_encode($target)
+                json_encode($target),
             ));
         }
 

--- a/src/Listener/FailedJobsListener.php
+++ b/src/Listener/FailedJobsListener.php
@@ -83,7 +83,7 @@ class FailedJobsListener implements EventListenerInterface
                 throw new RuntimeException(
                     sprintf('`logger` was not defined on %s event.', $event->getName()),
                     0,
-                    $e
+                    $e,
                 );
             }
 
@@ -91,7 +91,7 @@ class FailedJobsListener implements EventListenerInterface
                 throw new RuntimeException(
                     sprintf('`logger` is not an instance of `LoggerInterface` on %s event.', $event->getName()),
                     0,
-                    $e
+                    $e,
                 );
             }
 

--- a/src/Mailer/Transport/QueueTransport.php
+++ b/src/Mailer/Transport/QueueTransport.php
@@ -54,7 +54,7 @@ class QueueTransport extends AbstractTransport
                 'returnPath',
                 'cc',
                 'bcc',
-            ]
+            ],
         );
 
         return ['headers' => $headers, 'message' => 'Message has been enqueued'];
@@ -72,7 +72,7 @@ class QueueTransport extends AbstractTransport
         QueueManager::push(
             [SendMailJob::class, 'execute'],
             $data,
-            $options
+            $options,
         );
     }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -53,7 +53,7 @@ class Plugin extends BasePlugin
         if (!Configure::read('Queue')) {
             throw new InvalidArgumentException(
                 'Missing `Queue` configuration key, please check the CakePHP Queue documentation' .
-                ' to complete the plugin setup.'
+                ' to complete the plugin setup.',
             );
         }
 

--- a/src/QueueManager.php
+++ b/src/QueueManager.php
@@ -20,8 +20,8 @@ use BadMethodCallException;
 use Cake\Cache\Cache;
 use Cake\Core\App;
 use Cake\Log\Log;
+use Cake\Queue\Enqueue\SimpleClient;
 use Enqueue\Client\Message as ClientMessage;
-use Enqueue\SimpleClient\SimpleClient;
 use InvalidArgumentException;
 use LogicException;
 
@@ -162,7 +162,7 @@ class QueueManager
      * Get a queueing engine
      *
      * @param string $name Key name of a configured adapter to get.
-     * @return \Enqueue\SimpleClient\SimpleClient
+     * @return \Cake\Queue\Enqueue\SimpleClient
      */
     public static function engine(string $name): SimpleClient
     {
@@ -232,7 +232,7 @@ class QueueManager
         if (!empty($class::$shouldBeUnique)) {
             if (empty($config['uniqueCache'])) {
                 throw new InvalidArgumentException(
-                    "$class::\$shouldBeUnique is set to `true` but `uniqueCache` configuration is missing."
+                    "$class::\$shouldBeUnique is set to `true` but `uniqueCache` configuration is missing.",
                 );
             }
 
@@ -241,7 +241,7 @@ class QueueManager
             if (Cache::read($uniqueId, $config['uniqueCacheKey'])) {
                 if ($logger) {
                     $logger->debug(
-                        "An identical instance of $class already exists on the queue. This push will be ignored."
+                        "An identical instance of $class already exists on the queue. This push will be ignored.",
                     );
                 }
 

--- a/tests/TestCase/Enqueue/SimpleClientTest.php
+++ b/tests/TestCase/Enqueue/SimpleClientTest.php
@@ -1,0 +1,219 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org/)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         3.0.0
+ * @license       https://opensource.org/licenses/MIT MIT License
+ */
+namespace Cake\Queue\Test\TestCase\Enqueue;
+
+use Cake\Queue\Enqueue\SimpleClient;
+use DateTime;
+use Enqueue\Consumption\ChainExtension;
+use Enqueue\Consumption\Extension\LimitConsumedMessagesExtension;
+use Enqueue\Consumption\Extension\LimitConsumptionTimeExtension;
+use Enqueue\Consumption\Result;
+use Interop\Queue\Exception\PurgeQueueNotSupportedException;
+use Interop\Queue\Message;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class SimpleClientTest extends TestCase
+{
+    public static function transportConfigDataProvider()
+    {
+        yield 'amqp_dsn' => [[
+            'transport' => getenv('AMQP_DSN'),
+        ], '+1sec'];
+
+        yield 'dbal_dsn' => [[
+            'transport' => getenv('DOCTRINE_DSN'),
+        ], '+1sec'];
+
+        yield 'rabbitmq_stomp' => [[
+            'transport' => [
+                'dsn' => getenv('RABITMQ_STOMP_DSN'),
+                'lazy' => false,
+                'management_plugin_installed' => true,
+            ],
+        ], '+1sec'];
+
+        yield 'predis_dsn' => [[
+            'transport' => [
+                'dsn' => getenv('PREDIS_DSN'),
+                'lazy' => false,
+            ],
+        ], '+1sec'];
+
+        yield 'fs_dsn' => [[
+            'transport' => 'file://' . sys_get_temp_dir(),
+        ], '+1sec'];
+
+        yield 'sqs' => [[
+            'transport' => [
+                'dsn' => getenv('SQS_DSN'),
+            ],
+        ], '+1sec'];
+
+        yield 'mongodb_dsn' => [[
+            'transport' => getenv('MONGO_DSN'),
+        ], '+1sec'];
+    }
+
+    public function testShouldWorkWithStringDsnConstructorArgument()
+    {
+        $actualMessage = null;
+
+        $client = new SimpleClient(getenv('AMQP_DSN'));
+
+        $client->bindTopic('foo_topic', function (Message $message) use (&$actualMessage) {
+            $actualMessage = $message;
+
+            return Result::ACK;
+        });
+
+        $client->setupBroker();
+        $this->purgeQueue($client);
+
+        $client->sendEvent('foo_topic', 'Hello there!');
+
+        $client->getQueueConsumer()->setReceiveTimeout(200);
+        $client->consume(new ChainExtension([
+            new LimitConsumptionTimeExtension(new DateTime('+1sec')),
+            new LimitConsumedMessagesExtension(2),
+        ]));
+
+        $this->assertInstanceOf(Message::class, $actualMessage);
+        $this->assertSame('Hello there!', $actualMessage->getBody());
+    }
+
+    #[DataProvider('transportConfigDataProvider')]
+    public function testSendEventWithOneSubscriber($config, string $timeLimit)
+    {
+        $actualMessage = null;
+
+        $config['client'] = [
+            'prefix' => str_replace('.', '', uniqid('enqueue', true)),
+            'app_name' => 'simple_client',
+            'router_topic' => 'test',
+            'router_queue' => 'test',
+            'default_queue' => 'test',
+        ];
+
+        $client = new SimpleClient($config);
+
+        $client->bindTopic('foo_topic', function (Message $message) use (&$actualMessage) {
+            $actualMessage = $message;
+
+            return Result::ACK;
+        });
+
+        $client->setupBroker();
+        $this->purgeQueue($client);
+
+        $client->sendEvent('foo_topic', 'Hello there!');
+
+        $client->getQueueConsumer()->setReceiveTimeout(200);
+        $client->consume(new ChainExtension([
+            new LimitConsumptionTimeExtension(new DateTime($timeLimit)),
+            new LimitConsumedMessagesExtension(2),
+        ]));
+
+        $this->assertInstanceOf(Message::class, $actualMessage);
+        $this->assertSame('Hello there!', $actualMessage->getBody());
+    }
+
+    #[DataProvider('transportConfigDataProvider')]
+    public function testSendEventWithTwoSubscriber($config, string $timeLimit)
+    {
+        $received = 0;
+
+        $config['client'] = [
+            'prefix' => str_replace('.', '', uniqid('enqueue', true)),
+            'app_name' => 'simple_client',
+            'router_topic' => 'test',
+            'router_queue' => 'test',
+            'default_queue' => 'test',
+        ];
+
+        $client = new SimpleClient($config);
+
+        $client->bindTopic('foo_topic', function () use (&$received) {
+            ++$received;
+
+            return Result::ACK;
+        });
+        $client->bindTopic('foo_topic', function () use (&$received) {
+            ++$received;
+
+            return Result::ACK;
+        });
+
+        $client->setupBroker();
+        $this->purgeQueue($client);
+
+        $client->sendEvent('foo_topic', 'Hello there!');
+        $client->getQueueConsumer()->setReceiveTimeout(200);
+        $client->consume(new ChainExtension([
+            new LimitConsumptionTimeExtension(new DateTime($timeLimit)),
+            new LimitConsumedMessagesExtension(3),
+        ]));
+
+        $this->assertSame(2, $received);
+    }
+
+    #[DataProvider('transportConfigDataProvider')]
+    public function testSendCommand($config, string $timeLimit)
+    {
+        $received = 0;
+
+        $config['client'] = [
+            'prefix' => str_replace('.', '', uniqid('enqueue', true)),
+            'app_name' => 'simple_client',
+            'router_topic' => 'test',
+            'router_queue' => 'test',
+            'default_queue' => 'test',
+        ];
+
+        $client = new SimpleClient($config);
+
+        $client->bindCommand('foo_command', function () use (&$received) {
+            ++$received;
+
+            return Result::ACK;
+        });
+
+        $client->setupBroker();
+        $this->purgeQueue($client);
+
+        $client->sendCommand('foo_command', 'Hello there!');
+        $client->getQueueConsumer()->setReceiveTimeout(200);
+        $client->consume(new ChainExtension([
+            new LimitConsumptionTimeExtension(new DateTime($timeLimit)),
+            new LimitConsumedMessagesExtension(1),
+        ]));
+
+        $this->assertSame(1, $received);
+    }
+
+    protected function purgeQueue(SimpleClient $client): void
+    {
+        $driver = $client->getDriver();
+
+        $queue = $driver->createQueue($driver->getConfig()->getDefaultQueue());
+
+        try {
+            $client->getDriver()->getContext()->purgeQueue($queue);
+        } catch (PurgeQueueNotSupportedException $e) {
+        }
+    }
+}

--- a/tests/TestCase/Job/MailerJobTest.php
+++ b/tests/TestCase/Job/MailerJobTest.php
@@ -71,7 +71,7 @@ class MailerJobTest extends TestCase
             ->with(
                 $this->equalTo('welcome'),
                 $this->equalTo($this->args),
-                $this->equalTo($this->headers)
+                $this->equalTo($this->headers),
             )
             ->willReturn(['Message sent']);
 
@@ -79,7 +79,7 @@ class MailerJobTest extends TestCase
             ->method('getMailer')
             ->with(
                 $this->equalTo('SampleTest'),
-                $this->equalTo($this->mailerConfig)
+                $this->equalTo($this->mailerConfig),
             )->willReturn($this->mailer);
 
         $message = $this->createMessage();
@@ -101,7 +101,7 @@ class MailerJobTest extends TestCase
             ->method('getMailer')
             ->with(
                 $this->equalTo('SampleTest'),
-                $this->equalTo($this->mailerConfig)
+                $this->equalTo($this->mailerConfig),
             )->willThrowException(new MissingMailerException('Missing mailer for testExecuteMissingMailerException'));
 
         $message = $this->createMessage();
@@ -121,7 +121,7 @@ class MailerJobTest extends TestCase
             ->with(
                 $this->equalTo('welcome'),
                 $this->equalTo($this->args),
-                $this->equalTo($this->headers)
+                $this->equalTo($this->headers),
             )
             ->willThrowException(new BadMethodCallException('Welcome is not a valid method'));
 
@@ -129,7 +129,7 @@ class MailerJobTest extends TestCase
             ->method('getMailer')
             ->with(
                 $this->equalTo('SampleTest'),
-                $this->equalTo($this->mailerConfig)
+                $this->equalTo($this->mailerConfig),
             )->willReturn($this->mailer);
 
         $message = $this->createMessage();

--- a/tests/TestCase/Listener/FailedJobsListenerTest.php
+++ b/tests/TestCase/Listener/FailedJobsListenerTest.php
@@ -77,7 +77,7 @@ class FailedJobsListenerTest extends TestCase
         $event = new Event(
             'Consumption.LimitAttemptsExtension.failed',
             $message,
-            ['exception' => 'some message']
+            ['exception' => 'some message'],
         );
 
         /** @var \Cake\Queue\Model\Table\FailedJobsTable $failedJobsTable */
@@ -161,7 +161,7 @@ class FailedJobsListenerTest extends TestCase
         $event = new Event(
             'Consumption.LimitAttemptsExtension.failed',
             $message,
-            $eventData
+            $eventData,
         );
 
         $this->expectException(RuntimeException::class);

--- a/tests/TestCase/Mailer/Transport/QueueTransportTest.php
+++ b/tests/TestCase/Mailer/Transport/QueueTransportTest.php
@@ -67,7 +67,7 @@ class QueueTransportTest extends TestCase
                 'returnPath',
                 'cc',
                 'bcc',
-            ]
+            ],
         );
 
         $expected = ['headers' => $headers, 'message' => 'Message has been enqueued'];
@@ -93,7 +93,7 @@ class QueueTransportTest extends TestCase
             'queue' => 'default',
             'url' => $this->getFsQueueUrl(),
         ]);
-        $message = (new Message());
+        $message = new Message();
 
         $transport = new QueueTransport([
             'transport' => SmtpTransport::class,
@@ -124,7 +124,7 @@ class QueueTransportTest extends TestCase
             'queue' => 'default',
             'url' => $this->getFsQueueUrl(),
         ]);
-        $message = (new Message());
+        $message = new Message();
 
         $transport = new QueueTransport([
             'transport' => SmtpTransport::class,

--- a/tests/TestCase/Task/JobTaskTest.php
+++ b/tests/TestCase/Task/JobTaskTest.php
@@ -73,7 +73,7 @@ class JobTaskTest extends TestCase
         $this->assertOutputContains('Creating file ' . $this->generatedFile);
         $this->assertSameAsFile(
             $this->comparisonDir . 'JobTask.php',
-            file_get_contents($this->generatedFile)
+            file_get_contents($this->generatedFile),
         );
     }
 
@@ -87,7 +87,7 @@ class JobTaskTest extends TestCase
         $this->assertOutputContains('Creating file ' . $this->generatedFile);
         $this->assertSameAsFile(
             $this->comparisonDir . 'JobTaskWithUnique.php',
-            file_get_contents($this->generatedFile)
+            file_get_contents($this->generatedFile),
         );
     }
 
@@ -101,7 +101,7 @@ class JobTaskTest extends TestCase
         $this->assertOutputContains('Creating file ' . $this->generatedFile);
         $this->assertSameAsFile(
             $this->comparisonDir . 'JobTaskWithMaxAttempts.php',
-            file_get_contents($this->generatedFile)
+            file_get_contents($this->generatedFile),
         );
     }
 }


### PR DESCRIPTION
Since https://github.com/php-enqueue/simple-client is not that complicated (and to get rid of 1 more dependency) this is the first step to port over its functionality into the queue plugin.

I have not yet made the tests work, just copied them over and adjusted the namespaces, CS etc.

I am also not sure if we could also drop symfony 5 support here.

If we go this way, this of course requires a new major, therefore I made a new 3.x branch based on current 2.next.