### PR TITLE
Add timing to queue Processor events

### DIFF
--- a/src/Queue/Processor.php
+++ b/src/Queue/Processor.php
@@ -79,6 +79,7 @@ class Processor implements InteropProcessor
             return InteropProcessor::REJECT;
         }
 
+        $startTime = microtime(true) * 1000;
         $this->dispatchEvent('Processor.message.start', ['message' => $jobMessage]);
 
         try {
@@ -90,27 +91,39 @@ class Processor implements InteropProcessor
             $this->dispatchEvent('Processor.message.exception', [
                 'message' => $jobMessage,
                 'exception' => $e,
+                'duration' => (int)((microtime(true) * 1000) - $startTime),
             ]);
 
             return Result::requeue('Exception occurred while processing message');
         }
 
+        $duration = (int)((microtime(true) * 1000) - $startTime);
+
         if ($response === InteropProcessor::ACK) {
             $this->logger->debug('Message processed successfully');
-            $this->dispatchEvent('Processor.message.success', ['message' => $jobMessage]);
+            $this->dispatchEvent('Processor.message.success', [
+                'message' => $jobMessage,
+                'duration' => $duration,
+            ]);
 
             return InteropProcessor::ACK;
         }
 
         if ($response === InteropProcessor::REJECT) {
             $this->logger->debug('Message processed with rejection');
-            $this->dispatchEvent('Processor.message.reject', ['message' => $jobMessage]);
+            $this->dispatchEvent('Processor.message.reject', [
+                'message' => $jobMessage,
+                'duration' => $duration,
+            ]);
 
             return InteropProcessor::REJECT;
         }
 
         $this->logger->debug('Message processed with failure, requeuing');
-        $this->dispatchEvent('Processor.message.failure', ['message' => $jobMessage]);
+        $this->dispatchEvent('Processor.message.failure', [
+            'message' => $jobMessage,
+            'duration' => $duration,
+        ]);
 
         return InteropProcessor::REQUEUE;
     }

--- a/tests/TestCase/Queue/ProcessorTest.php
+++ b/tests/TestCase/Queue/ProcessorTest.php
@@ -95,6 +95,11 @@ class ProcessorTest extends TestCase
         $data = $events[2]->getData();
         $this->assertArrayHasKey('message', $data);
         $this->assertSame($message->jsonSerialize(), $data['message']->jsonSerialize());
+
+        // Verify timing information is present in completion events
+        $this->assertArrayHasKey('duration', $data);
+        $this->assertIsInt($data['duration']);
+        $this->assertGreaterThanOrEqual(0, $data['duration']);
     }
 
     /**
@@ -154,6 +159,14 @@ class ProcessorTest extends TestCase
 
         $result = $processor->process($queueMessage, $context);
         $this->assertEquals(InteropProcessor::REQUEUE, $result);
+
+        // Verify timing information is present in exception event
+        $this->assertSame(3, $events->count());
+        $this->assertSame('Processor.message.exception', $events[2]->getName());
+        $data = $events[2]->getData();
+        $this->assertArrayHasKey('duration', $data);
+        $this->assertIsInt($data['duration']);
+        $this->assertGreaterThanOrEqual(0, $data['duration']);
     }
 
     /**


### PR DESCRIPTION
This PR adds a `duration` field (in milliseconds) to all queue Processor event payloads (`success`, `reject`, `failure`, `exception`).  
Test coverage is updated to assert that timing is present and valid in all completion events.

**Why:**  
- Enables accurate monitoring and performance analysis of queue jobs.
- Ensures all event consumers can rely on timing data.

No breaking changes.  
