### PR TITLE
Use BaseMigration instead of deprecated AbstractMigration

### DIFF
--- a/config/Migrations/20221007202459_CreateFailedJobs.php
+++ b/config/Migrations/20221007202459_CreateFailedJobs.php
@@ -1,15 +1,15 @@
 <?php
 declare(strict_types=1);
 
-use Migrations\AbstractMigration;
+use Migrations\BaseMigration;
 
-class CreateFailedJobs extends AbstractMigration
+class CreateFailedJobs extends BaseMigration
 {
     /**
      * Change Method.
      *
      * More information on this method is available here:
-     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+     * https://book.cakephp.org/migrations/4/en/migrations.html#the-change-method
      * @return void
      */
     public function change()


### PR DESCRIPTION
## Summary

- Update migration to use `BaseMigration` instead of the deprecated `AbstractMigration` class
- Update documentation link to point to CakePHP Migrations docs instead of Phinx