### PR TITLE
Fix getUniqueId with array data

### DIFF
--- a/src/QueueManager.php
+++ b/src/QueueManager.php
@@ -304,7 +304,7 @@ class QueueManager
      */
     public static function getUniqueId(string $class, string $method, array $data): string
     {
-        sort($data);
+        $data = static::sortUniqueValues($data);
 
         $hashInput = implode('', [
             $class,
@@ -313,5 +313,23 @@ class QueueManager
         ]);
 
         return hash('md5', $hashInput);
+    }
+
+    /**
+     * Recursively sort an array by key
+     *
+     * @param array $data The data to sort
+     * @return array The sorted array
+     */
+    protected static function sortUniqueValues(array $data): array
+    {
+        foreach ($data as $key => $value) {
+            if (is_array($value)) {
+                $data[$key] = static::sortUniqueValues($value);
+            }
+        }
+        ksort($data);
+
+        return $data;
     }
 }

--- a/src/QueueManager.php
+++ b/src/QueueManager.php
@@ -318,8 +318,8 @@ class QueueManager
     /**
      * Recursively sort an array by key
      *
-     * @param array $data The data to sort
-     * @return array The sorted array
+     * @param array<string, mixed> $data The data to sort
+     * @return array<string, mixed> The sorted array
      */
     protected static function sortUniqueValues(array $data): array
     {
@@ -328,6 +328,7 @@ class QueueManager
                 $data[$key] = static::sortUniqueValues($value);
             }
         }
+
         ksort($data);
 
         return $data;

--- a/tests/TestCase/QueueManagerTest.php
+++ b/tests/TestCase/QueueManagerTest.php
@@ -59,6 +59,42 @@ class QueueManagerTest extends TestCase
         array_map('unlink', glob($this->fsQueuePath . DS . '*'));
     }
 
+    public function testGetUniqueId()
+    {
+        $first = QueueManager::getUniqueId('Example', 'hello', [1, 2, 3]);
+        $second = QueueManager::getUniqueId('Example', 'hello', [3, 2, 1]);
+        $this->assertNotEquals($first, $second, 'values are sorted by key');
+
+        $second = QueueManager::getUniqueId('Human', 'hello', [3, 2, 1]);
+        $this->assertNotEquals($first, $second, 'class changes hash');
+
+        $second = QueueManager::getUniqueId('Example', 'bye', [3, 2, 1]);
+        $this->assertNotEquals($first, $second, 'method changes hash');
+
+        $first = QueueManager::getUniqueId('Example', 'hello', ['user_id' => 'admin', 'role' => 'guest']);
+        $second = QueueManager::getUniqueId('Example', 'hello', ['user_id' => 'admin', 'role' => 'guest']);
+        $this->assertSame($first, $second, 'same values and keys are the same');
+
+        $second = QueueManager::getUniqueId('Example', 'hello', ['role' => 'guest', 'user_id' => 'admin']);
+        $this->assertSame($first, $second, 'reordered keys are the same');
+
+        $first = QueueManager::getUniqueId('Example', 'hello', ['user_id' => 'admin', 'role' => 'guest']);
+        $second = QueueManager::getUniqueId('Example', 'hello', ['user_id' => 'admin', 'role' => 'admin']);
+        $this->assertNotEquals($first, $second, 'different values are distinct');
+
+        $first = QueueManager::getUniqueId('Example', 'hello', ['foo' => 'admin', 'bar' => 'guest']);
+        $second = QueueManager::getUniqueId('Example', 'hello', ['user_id' => 'admin', 'role' => 'guest']);
+        $this->assertNotEquals($first, $second, 'different keys, same values are distinct');
+
+        $first = QueueManager::getUniqueId('Example', 'hello', ['foo' => 'foo', 'bar' => 'foo']);
+        $second = QueueManager::getUniqueId('Example', 'hello', ['user_id' => 'admin', 'role' => 'guest']);
+        $this->assertNotEquals($first, $second, 'different keys and values, are distinct');
+
+        $first = QueueManager::getUniqueId('Example', 'hello', ['arr' => ['a' => 1, 'b' => 2]]);
+        $second = QueueManager::getUniqueId('Example', 'hello', ['arr' => ['b' => 2, 'a' => 1]]);
+        $this->assertEquals($first, $second, 'nested arrays are sorted too');
+    }
+
     public function testSetConfig()
     {
         QueueManager::setConfig('test', [


### PR DESCRIPTION
The QueueManager::getUniqueId() should not drop keys when sorting to create canonical data shapes for idempotency keys. Dropping keys allows data with different key semantics to be the 'same'. Instead we should recursively sort data by key.

Thanks to Volker Dusch and the PHP Ecosystem security team for reporting this.