### PR TITLE
Pin action image and reduce permissions

### DIFF
--- a/.github/workflows/deploy_docs_1x.yml
+++ b/.github/workflows/deploy_docs_1x.yml
@@ -7,6 +7,9 @@ on:
       - 1.x
   workflow_dispatch:
 
+permissions:
+    contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -17,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Push to dokku
-        uses: dokku/github-action@master
+        uses: dokku/github-action@cc7dec1d2b9fed249a14ae462bc953bba436f78c # v1.10.0
         with:
           git_remote_url: 'ssh://dokku@apps.cakephp.org:22/queue-docs-1'
           ssh_private_key: ${{ secrets.DOKKU_SSH_PRIVATE_KEY }}

--- a/.github/workflows/deploy_docs_2x.yml
+++ b/.github/workflows/deploy_docs_2x.yml
@@ -7,6 +7,9 @@ on:
       - 2.x
   workflow_dispatch:
 
+permissions:
+    contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -17,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Push to dokku
-        uses: dokku/github-action@master
+        uses: dokku/github-action@cc7dec1d2b9fed249a14ae462bc953bba436f78c # v1.10.0
         with:
           git_remote_url: 'ssh://dokku@apps.cakephp.org:22/queue-docs-2'
           git_push_flags: '-f'


### PR DESCRIPTION
Pin the image revision used for dokku deployments and reduce permissions for deploy jobs. Pinning the image revision reduces the chances of supply chain attacks on images with access to real credentials.